### PR TITLE
Minor Fixes Before Holiday and V0.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,14 +4,13 @@ temp/
 build/
 bin/
 
-samples/TheAlgorithmsC/
-samples/EggListener.c
-samples/OG/
-database/
-preprocessed/*
-filteredFiles/*
-benchmark/*
-database/*
+/samples/TheAlgorithmsC/
+/samples/EggListener.c
+/samples/OG/
+/preprocessed/*
+/filteredFiles/*
+/benchmark/*
+/database/*
 
 compile_commands.json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,6 @@ set(CMAKE_CXX_COMPILER clang++)
 set(CMAKE_C_COMPILER clang)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-# set(CMAKE_CXX_STANDARD 17)
-# set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "../bin")
-# set(CMAKE_C_STANDARD 99)
-# set(CMAKE_C_STANDARD_REQUIRED ON)
-
 
 project(
   argv-argc-transformer
@@ -19,7 +13,19 @@ project(
 
 find_package(Clang REQUIRED)
 find_package(LLVM REQUIRED)
-# find_package(libgit2 REQUIRED)
+
+# NOTE: If adding the downloader to the build system is desirable
+# find_package(Python3 REQUIRED COMPONENTS Interpreter)
+# add_custom_target(
+#   download
+#   COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/src/download/Downloader.py
+#   COMMENT "Running the Downloader"
+# )
+# NOTE: Immediatly executes instead of on user command
+
+# Can be used to enforce downloader to run before filter?
+# add_dependencies(filter download)
+
 
 set(HEADERS_FILTER
   src/filter/include
@@ -74,23 +80,6 @@ set(SOURCE_EXAMPLE
 # )
 
 include(FetchContent)
-
-# FetchContent_Declare(
-#   fmt
-#   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-#   GIT_TAG 11.1.3
-# )
-
-# FetchContent_GetProperties(fmt)
-# if(NOT fmt_POPULATED)
-#   FetchContent_MakeAvailable(fmt)
-# endif()
-
-# FetchContent_Declare(
-#   rapidcsv
-#   GIT_REPOSITORY d99kris/rapidcsv
-#   GIT_TAG v8.84
-# )
 
 include_directories(${LLVM_INCLUDE_DIRS} ${Clang_INCLUDE_DIRS} ${LLVM_INC} ${CLANG_INC} /usr/local )
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
   - [Running the Code](#running-the-code)
   - [Targets](#targets)
   - [Scripts](#scripts)
+    - [For Running on Sample Code](#for-running-on-sample-code)
+    - [For Running on Live Code](#for-running-on-live-code)
+    - [For Cleaning In Between Major Changes](#for-cleaning-in-between-major-changes)
 <!--toc:end-->
 
 ArgC transformer takes directories with c files or individual c files and

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 <!--toc:start-->
 - [ArgV C Transformer](#argv-c-transformer)
-- [Running the Code](#running-the-code)
   - [Dependencies](#dependencies)
     - [Clang Resources](#clang-resources)
-  - [Available Targets](#available-targets)
-  - [Temporary Scripts](#temporary-scripts)
+  - [Running the Code](#running-the-code)
+  - [Targets](#targets)
+  - [Scripts](#scripts)
 <!--toc:end-->
 
 ArgC transformer takes directories with c files or individual c files and
@@ -18,8 +18,8 @@ individual functions.
 
 To develop and run the code the following are needed:
 
-- llvm-devel
-- clang-devel
+- llvm developer toolkit
+- clang and the clang developer toolkit
 - cmake
 - make or ninja
 - a c++ compiler
@@ -30,13 +30,22 @@ To compile the ASTs without errors on includes from the c file standard library
 headers, the clang resource dir must be provided to the compiler. This is done
 via an environment variable called `CLANG_RESOURCES`. This must be set by the
 user on the system. The location of the resource directory can be found by
-running `clang -print-resource-dir`.
+running `clang -print-resource-dir`. The code cannot be run until this Variable
+has been set.
 
 ## Running the Code
 
-The project can be run on folders or individual files as specified by the user.
-The attributes used to filter out undesired functions are set via the
-config.properties file. To run any of the targets the user must first run the
+The project can be run on folders or individual files as specified by the user
+in the provided configuration file. The configuration file also provides all
+settings used by the filter and the transformer during the run. Such as the
+minimum number of loops needed or location of the filtered files.
+
+The name of the configuration file is passed to the program as a commandline
+argument and can be passed to a tool individually or, if using either the
+'run.sh' or 'liveRun.sh' scripts, to the program as a whole as the first and
+only argument.
+
+To run any of the targets the user must first run the
 cmake command followed by the make or ninja command, depending on the generator
 chosen. Examples of these commands on a unix system would look something like these.
 If generating from inside the build folder:
@@ -67,33 +76,49 @@ ninja -C build -j2
 ./build/<TARGET> <args>
 ```
 
-Would set the generator to ninja then use 2 processors to compile, then run the
-chosen target.
+This would set the generator to ninja then use 2 processors to compile, then
+runs the chosen target.
 
-## Available Targets
+## Targets
 
-Filter requres that the user provides the location of the *dir-to-filter*, and
-the *propertiesFile*
+Filter requres that the user provides the location of the *configurationFile*
 
-Transform requres that the user provides the the location of the *dir-to-transform*
+Transform requres that the user provides the the location of the *configurationFile*
 
 Full requires that the user provide the
 *file/dir-to-filter* and the *propertiesFile* location
 
-## Temporary Scripts
+## Scripts
 
-2 Scripts are provided with similar functionality and can be modified to suit
-user needs as development continues.
+All scripts currently only exist for unix based systems. These can be adapted
+or used as a template for other systems if desired by the user but all changed
+scripts should remain local to the user's system.
 
-- The `run.sh` file runs does the cmake and build steps using ninja as the
-generator then clears the old results folders and runs the filter and transform
-sequentially with the necessary arguments. It also copies the compile_commands.json
-file to the root dir. This file is used by many ide's for linting.
-- The `fullRun.sh` script runs the full target comprised of all current parts
-using the same arguments and default locations
+### For Running on Sample Code
 
-There is also a `clean.sh` script provided that cleans the build folder without
-destroying the dependencies.
+- `run.sh <config-file-name>`:
+  - runs cmake from root using Ninja as the Generator
+  - clears all old results folders
+  - runs the filter and transform sequentially with specified config file
+  - It also copies the compile_commands.json file to the root dir (This file is
+  used by many ide's for linting)
+
+### For Running on Live Code
+
+- `liveRun.sh <config-file-name>`
+  - runs cmake from root using Ninja as the Generator
+  - clears all old results folders
+  - runs the downloader pulling live repositories from github
+    - the repos pulled are found in the specified csv file and are filtered by
+    the downloader
+  - runs the filter and transform sequentially with specified config file
+  - It also copies the compile_commands.json file to the root dir (This file is
+  used by many ide's for linting)
+
+### For Cleaning In Between Major Changes
+
+- `clean.sh`
+  - script provided that cleans the build folder without destroying the dependencies.
 
 These scripts can act as a template for user scripts or as an example on how to
 run the code on unix based systems.

--- a/checkComp.sh
+++ b/checkComp.sh
@@ -1,23 +1,42 @@
 #!/bin/sh
 
-for file in *.c; do
-  clang -fsyntax-only verifier.c "$file"
-done
+success_count=0
+total_attempts=0
 
 if [ -f "$1" ]; then
   echo "Running for ${1}"
-  clang -fsyntax-only verifier.c "$1"
+  clang -xc -I -w -resource-dir="$CLANG_RESOURCES" -fsyntax-only verifier.c "$1" > /dev/null 2>&1
   exit 0
 elif [ -d "$1" ]; then
   echo "Running for Dir: ${1}"
-  echo "If only the <name> prints then the compilation is a SUCESS"
-  find "$1" -name "*.c" -type f -exec echo "Checking for Errors in: " {} \; -exec clang -fsyntax-only verifier.c {} \;
-  # for item in "$1"/*; do
-  #   echo "$item"
-  #   if [ -f "$item" ]; then
-  #     echo "Running for ${item}"
-  #     clang -fsyntax-only verifier.c "$1"
-  #   fi
-  # done
-  exit 0
+  temp_results=$(mktemp)
+
+  find "$1" -name "*.c" -type f -exec sh -c '
+    file="$0"
+    clang -xc -I -w -resource-dir="$CLANG_RESOURCES" -fsyntax-only verifier.c "$file" > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      echo "SUCCESS:$file"
+    else
+      echo "ERROR:$file"
+    fi
+  ' {} \; > "$temp_results"
+
+  while IFS= read -r line; do
+    total_attempts=$((total_attempts + 1))
+    if echo "$line" | grep -q "^SUCCESS:"; then
+      # echo " $(echo "$line" | sed "{s/$success//}")"
+      echo "$line"
+      success_count=$((success_count + 1))
+    elif echo "$line" | grep -q "^ERROR:"; then
+      # echo " $(echo "$line" | sed "{s/$errors//}")"
+      echo "$line"
+    fi
+  done < "$temp_results"
+  rm -f "$temp_results"
 fi
+echo ""
+echo "--- Summary ---"
+echo "Total Files Checked: $total_attempts"
+echo "Total Successes: $success_count"
+
+exit "$success_count"

--- a/liveRun.sh
+++ b/liveRun.sh
@@ -25,14 +25,17 @@ echo "=================================== Reset Directories ====================
 rm -r filteredFiles/*
 rm -r benchmark/*
 
-set -e
+# set -e
 
 echo "=================================== Using Resources ==================================="
 clangResourceDir="$(clang -print-resource-dir)"
 echo "Using Resource Directory: $clangResourceDir"
 
+echo "=================================== Run Downdload ================================="
+python3 ./src/download/Downloader.py "$configFile"
+
 echo "=================================== Run Filter ==================================="
-./build/filter "$configFile"
+./build/filter "$configFile" 
 
 echo "=================================== Run Transform ==================================="
-./build/transform "$configFile"
+./build/transform "$configFile" 

--- a/properties.config
+++ b/properties.config
@@ -1,6 +1,8 @@
 [File Locations]
 csv=dataset.csv
 downloadDir=database
+databaseDir=database
+filterDir=filteredFiles
 benchmarkDir=benchmarks
 
 [Downloading]
@@ -13,7 +15,7 @@ maxRepoLoc=10000
 
 
 [Function Requirements]
-maxForLoops = 1
+maxForLoops = 9999
 minTypeCompareOperation = 0
 minTypeIfStmt = 0
 minTypeArithmeticOperation = 1
@@ -25,7 +27,7 @@ type=Int
 minFileLoC=0
 maxFileLoC=9999
 useNonStdHeaders=false
-keepCompilesOnly=true
+keepCompilesOnly=false
 
 [Debugging Flags]
 debug=false

--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,7 @@ clangResourceDir="$(clang -print-resource-dir)"
 echo "Using Resource Directory: $clangResourceDir"
 
 echo "=================================== Run Filter ==================================="
-./build/filter samples/Tester/ properties.config
+./build/filter properties.config
 
 echo "=================================== Run Transform ==================================="
-./build/transform filteredFiles/
+./build/transform properties.config

--- a/src/download/Downloader.py
+++ b/src/download/Downloader.py
@@ -1,3 +1,4 @@
+import sys
 import csv
 import os
 import requests
@@ -6,62 +7,70 @@ import tempfile
 import time
 import configparser
 
-start = time.time()
-
 # default settings
-settings = {
+downloadSettings = {
     'language': 'C',
     'minRepoLoC': "100",
     'projectCount': "5",
     'minNumStars': "1"
 }
 
-if (os.path.exists("properties.config")):
+fileSettings = {
+    'csv': 'dataset.csv',
+    'downloadDir': 'database',
+    'databaseDir': 'database'
+}
+
+if (sys.argv.__sizeof__() > 1):
+    configFile = sys.argv[1]
+else:
+    print(f"No Config File Provided.\nAborting Download")
+
+if (os.path.exists(configFile)):
     config = configparser.ConfigParser()
-    config.read('properties.config')
+    config.read(configFile)
     # print(config.sections())
-    for setting in settings:
+    for setting in downloadSettings:
         try:
-            settings[setting] = config['Downloading'][setting]
+            downloadSettings[setting] = config['Downloading'][setting]
+        except KeyError as e:
+            print(f"KeyError: {e} On Setting {setting}")
+    for setting in fileSettings:
+        try:
+            fileSettings[setting] = config['File Locations'][setting]
         except KeyError as e:
             print(f"KeyError: {e} On Setting {setting}")
 
-print(f"Settings: {settings}")
+print(f"Settings:\n\t{downloadSettings}\n\t{fileSettings}")
 
-if (os.path.exists("c_repos.csv")):
-    os.remove("c_repos.csv")
-
-with open('dataset.csv', newline='') as csv_file:
-    with open('c_repos.csv', 'w', newline='') as new_file:
-        writer = csv.writer(new_file)
+if (os.path.exists(fileSettings['csv'])):
+    with open(fileSettings['csv'], newline='') as csv_file:
         reader = csv.DictReader(csv_file)
         column_names = reader.fieldnames
-        # print(column_names)
-        writer.writerow(column_names)
         i = 0
+        start = time.time()
         for row in reader:
-            if (i >= (int)(settings['projectCount'])):
+            if (i >= (int)(downloadSettings['projectCount'])):
                 break
-            if (row['language'] == settings['language'] 
-                    and (int)(row['size']) >= (int)(settings['minRepoLoC'])):
+            if (row['language'] == downloadSettings['language'] 
+                    and (int)(row['size']) >= (int)(downloadSettings['minRepoLoC'])
+                    and (int)(row['stars']) >= (int)(downloadSettings['minNumStars'])):
                 repo_url = f"https://github.com/{row["repository"]}"
                 if requests.head(repo_url).status_code != 200:
                     continue
-                location = "database/" + row["repository"]
+                location = os.path.join(fileSettings['downloadDir'], row["repository"])
                 i += 1
                 print(f"Attempting to Clone {location}")
                 if (not os.path.exists(location)):
                     try:
                         print(f"Cloning: {row["repository"]}")
                         repo = Repo.clone_from(repo_url+".git", location, progress=RemoteProgress.update(0, 0, 0), multi_options=["--depth=1"])
-                        writer.writerow(row.values())
                         print(f"Finished")
                     except GitError as e:
                         print(f"Error: {e}")
                 else:
                     print(f"{location} already exists")
 
-
-end = time.time()
+        end = time.time()
 
 print(f"Total Time: {end - start}")

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -261,7 +261,15 @@ int Filterer::run() {
 
       clang::IgnoringDiagConsumer diagConsumer;
 
-      std::string resourceDir = std::getenv("CLANG_RESOURCES");
+      std::string resourceDir;
+      try {
+        resourceDir = std::getenv("CLANG_RESOURCES");
+      } catch (...) {
+        std::cout << "Please set the CLANG_RESOURCES environment vairable "
+                     "before proceeding"
+                  << std::endl;
+        return 1;
+      }
 
       /// Set args for AST creation
       std::vector<std::string> args = std::vector<std::string>({

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -17,9 +17,11 @@
 #include <regex>
 #include <string>
 
-Filterer::Filterer(){
+Filterer::Filterer(std::string configFile){
   typesRequested = std::vector<unsigned int>();
   typeNames = std::vector<std::string>();
+  parseConfigFile(configFile);
+
 };
 
 // Parse the config file for all settings as well as a list of desired types
@@ -78,8 +80,25 @@ void Filterer::parseConfigFile(std::string configFile) {
             }
             value = typeMatches.suffix().str();
           }
-        }
-        else {
+        } else if (key == "databaseDir") {
+          if (std::filesystem::exists(value)) {
+            configuration.databaseDir = value;
+          } else {
+            configuration.databaseDir = "database";
+          }
+        } else if (key == "filterDir") {
+          if (std::filesystem::exists(value)) {
+            configuration.filterDir = value;
+          } else {
+            configuration.filterDir = "filteredFiles";
+          }
+        } else if (key == "debugLevel") {
+          try {
+            configuration.debugLevel = std::stoi(value);
+          } catch (...) {
+            configuration.debugLevel = 0;
+          }
+        } else {
           std::cout << "Key: " << key
             << " Is Not A Valid Key For Filtering Files" << std::endl;
         }
@@ -97,6 +116,9 @@ void Filterer::parseConfigFile(std::string configFile) {
   } else {
     std::cerr << "File Failed to Open" << std::endl;
     std::cout << "Using Default Settings" << std::endl;
+    configuration.debugLevel = 0;
+    configuration.filterDir = "filtereredFiles";
+    configuration.databaseDir = "database";
   }
 }
 
@@ -203,14 +225,11 @@ void Filterer::debugInfo(std::string info) {
 }
 
 /// Main driver for the Filter System
-int Filterer::run(std::string fileOrDirToFilter,
-                  std::string propertiesConfigFile) {
+int Filterer::run() {
 
   std::cout << "starting" << std::endl;
 
-  parseConfigFile(propertiesConfigFile);
-
-  std::filesystem::path pathObject(fileOrDirToFilter);
+  std::filesystem::path pathObject(configuration.databaseDir);
 
   std::vector<std::string> filesToFilter = std::vector<std::string>();
 

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -34,7 +34,7 @@ void Filterer::parseConfigFile(std::string configFile) {
   }
   if (file.is_open()) {
     std::cout << "Using: " << configFile << " Specified Settings" << std::endl;
-    std::regex pattern("^\\s*(\\w+)\\s*=\\s*([0-9]+|[\\w\\s,]+)$");
+    std::regex pattern("^\\s*(\\w+)\\s*=\\s*([0-9]+|[\\w\\s,]+|[\\w/-_.]+)$");
     std::string line;
     std::smatch match;
     while (std::getline(file, line)) {

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -25,6 +25,7 @@ Filterer::Filterer(std::string configFile){
 };
 
 // Parse the config file for all settings as well as a list of desired types
+/// TODO MAKE THE PARSERS MORE SECURE!!
 void Filterer::parseConfigFile(std::string configFile) {
   std::ifstream file(configFile);
   if (!std::filesystem::exists(configFile)) {

--- a/src/filter/include/Filterer.hpp
+++ b/src/filter/include/Filterer.hpp
@@ -6,10 +6,16 @@
 #include <string>
 #include <vector>
 
+struct filterConfigs {
+  std::string databaseDir;
+  std::string filterDir;
+  int debugLevel;
+};
+
 class Filterer {
 public:
   /// Constructor for the Filterer Object
-  Filterer();
+  Filterer(std::string configFile);
 
   /// Parse the config file creating the config map used by the rest of the
   /// filter steps
@@ -32,8 +38,7 @@ public:
 
   /// Main driver for the rest of the code creating the filter tool and running
   /// it on each file found in the path that has potential
-  int run(std::string fileOrDirToFilter    = "database",
-          std::string propertiesConfigFile = "properties.config");
+  int run();
 
 private:
   /// vector of all standard library names to compare includes to
@@ -52,7 +57,7 @@ private:
   /// Map of Valid Config Settings with Default Values
   std::map<std::string, int> *config = new std::map<std::string, int>({
     {"debug", 1},
-    {"debugLevel", 0},
+    // {"debugLevel", 0},
     {"maxCallFunc", 99999},
     {"maxFileLoC", 2000},
     {"maxForLoops", 99999},
@@ -89,4 +94,5 @@ private:
     {"minWhileLoops", 0},
     {"useNonStdHeaders", 0}
   });
+  struct filterConfigs configuration;
 };

--- a/src/filter/main.cpp
+++ b/src/filter/main.cpp
@@ -3,19 +3,16 @@
 
 // Target for calling the Filterer Individually
 int main(int argc, char** argv) {
-  Filterer filter;
-  if (argc == 3) {
-    filter.run(argv[1], argv[2]);
-  } else if (argc < 1) {
-    filter.run(argv[1]);
+  if (argc == 2) {
+    Filterer filter(argv[1]);
+    filter.run();
   } else {
   std::cout << "Incorrect Number of Args" << std::endl;
   std::cout << "Please Give the Location of the File or Directory to Filter "
                "and the Location of the Configuration File\n"
-               "and the Location of the Clang Resource Directory\n"
-               "    This can be found by running 'clang -print-resource-dir'\n"
-               "Example: `<filter-directory> <config-file> <Resource-Dir>`"
+               "Example: `./build/filter <config-file>`"
             << std::endl;
   return 1;
   }
+  return 0;
 }

--- a/src/full/main.cpp
+++ b/src/full/main.cpp
@@ -2,26 +2,23 @@
 #include "Transformer.hpp"
 #include <iostream>
 
+// TODO OVER HAUL THIS WHOLE THING TO MAKE SENSE AGAIN
 int main(int argc, char** argv) {
 	if (argc == 4) {
-    Filterer filter;
-    filter.run(argv[1], argv[2]);
+    Filterer filter(argv[1]);
+    filter.run();
 
-    Transformer transformer;
-    transformer.run(argv[1]);
+    Transformer transformer(argv[1]);
+    transformer.run();
   } else if (argc > 1) {
-    Filterer filter;
-    filter.run(argv[1]);
+    Filterer filter(argv[1]);
+    filter.run();
 
-    Transformer transformer;
-    transformer.run(argv[1]);
+    Transformer transformer(argv[1]);
+    transformer.run();
 	} else {
   std::cout << "Incorrect Number of Args" << std::endl;
-  std::cout << "Please Give the Location of the:\n"
-      "File or Directory to Filter\n"
-      "Location of the Clang Resource Directory\n"
-      "    This can be found by running 'clang -print-resource-dir'\n"
-      "Location of the Configuration File\n"
+  std::cout << "Please Give the Location of the Configuration File\n"
       "    Example: `<filter-directory> <config-file> <Resource-Dir>`"
             << std::endl;
   return 1;

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -56,7 +56,15 @@ bool Transformer::transformFile(std::filesystem::path path) {
 
   clang::IgnoringDiagConsumer diagConsumer;
 
-  std::string resourceDir = std::getenv("CLANG_RESOURCES");
+  std::string resourceDir;
+  try {
+    resourceDir = std::getenv("CLANG_RESOURCES");
+  } catch (...) {
+    std::cout << "Please set the CLANG_RESOURCES environment vairable "
+      "before proceeding"
+      << std::endl;
+    return 1;
+  }
 
   std::cout << "Setting Comp Options" << std::endl;
 

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -121,7 +121,7 @@ bool Transformer::transformFile(std::filesystem::path path) {
   output.close();
 
   if (!checkCompilable(srcPath)) {
-    if (!configuration.keepCompilesOnly) {
+    if (configuration.keepCompilesOnly) {
       std::filesystem::remove(srcPath);
     }
     return 0;

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -122,8 +122,8 @@ bool Transformer::transformFile(std::filesystem::path path) {
 
   output.close();
 
-  if (!checkCompilable(path)) { // && !configs->keepCompilesOnly) {
-    // std::filesystem::remove(path);
+  if (!checkCompilable(srcPath)) { // TODO implement && !configs->keepCompilesOnly) {
+    // std::filesystem::remove(srcPath); // TODO this can be uses later for keeping only those that compile
     return 0;
   }
 
@@ -160,14 +160,14 @@ int Transformer::checkCompilable(std::filesystem::path path) {
 
   std::vector<std::string> compOptionsArgs({
     "clang",
-    path.string(),
-    "verifier.c",
-    "-extra-arg=-w",
     "-extra-arg=-fsyntax-only",
-    "-extra-arg=-fparse-all-comments",
-    "-extra-arg=-resource-dir=" + resourceDir,
     "-extra-arg=-xc",
-    "-extra-arg=-I"
+    "-extra-arg=-I",
+    "-extra-arg=-w",
+    "-extra-arg=-resource-dir=" + resourceDir,
+    "verifier.c",
+    path.string()
+    // "-extra-arg=-fparse-all-comments",
   });
 
   int argc = compOptionsArgs.size();
@@ -201,6 +201,7 @@ int Transformer::checkCompilable(std::filesystem::path path) {
   clang::DiagnosticConsumer diagConsumer;
   tool.setDiagnosticConsumer(&diagConsumer);
 
+  // tool.run(clang::tooling::newFrontendActionFactory<clang::PreprocessOnlyAction>().get());
   tool.run(clang::tooling::newFrontendActionFactory<clang::SyntaxOnlyAction>().get());
 
   // If there are errors do not count the file as compilable

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -18,6 +18,7 @@
 #include <clang/Tooling/Tooling.h>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <llvm/ADT/IntrusiveRefCntPtr.h>
 #include <llvm/ADT/StringRef.h>
 #include <iostream>
@@ -25,8 +26,13 @@
 #include <llvm/Support/VirtualFileSystem.h>
 #include <llvm/Support/raw_ostream.h>
 #include <memory>
+#include <regex>
 #include <string>
 #include <vector>
+
+Transformer::Transformer(std::string configFile) : configuration() {
+  parseConfig(configFile);
+}
 
 // Take an individual file and apply all transformations to it by generating 
 // the ast, visitors and regenerating the source code as precompiled .i file
@@ -204,14 +210,61 @@ int Transformer::checkCompilable(std::filesystem::path path) {
   return 1;
 }
 
-void Transformer::parseConfig() {
+void Transformer::parseConfig(std::string configFile) {
+  std::ifstream file(configFile);
+  if (!std::filesystem::exists(configFile)) {
+    std::cout << "File: " << configFile << " Does Not Exist" << std::endl;
+    std::cout << "Using Default Settings" << std::endl;
+    return;
+  }
+  if (file.is_open()) {
+    std::cout << "Using: " << configFile << " Specified Settings" << std::endl;
+    std::regex pattern("^\\s*(\\w+)\\s*=\\s*([0-9]+|[\\w\\s,]+)$");
+    std::string line;
+    std::smatch match;
+    while (std::getline(file, line)) {
+      if (std::regex_search(line, match, pattern)) {
+        std::string key = match[1];
+        std::string value = match[2];
+        // Add the value to the config if the key is a member of the map
+        if (key == "benchmarkDir") {
+          if (std::filesystem::exists(value)) {
+            configuration.benchmarkDir = value;
+          } else {
+            configuration.benchmarkDir = "database";
+          }
+        } else if (key == "filterDir") {
+          if (std::filesystem::exists(value)) {
+            configuration.filterDir = value;
+          } else {
+            configuration.filterDir = "filteredFiles";
+          }
+        } else if (key == "debugLevel") {
+          try {
+            configuration.debugLevel = std::stoi(value);
+          } catch (...) {
+            configuration.debugLevel = 0;
+          }
+        } else if (key == "keepCompilesOnly"){
+          configuration.keepCompilesOnly = (value == "true" || value == "True");
+        }
+      }
+    }
+    file.close();
+  } else {
+    std::cerr << "File Failed to Open" << std::endl;
+    std::cout << "Using Default Settings" << std::endl;
+    configuration.debugLevel = 0;
+    configuration.keepCompilesOnly = false;
+    configuration.filterDir = "filtereredFiles";
+    configuration.benchmarkDir = "benchmark";
+  }
 }
 
 // Main function should be transfered to a driver for use via the full implementation
-int Transformer::run(std::string filePath) {
-  std::filesystem::path path(filePath);
+int Transformer::run() {
+  std::filesystem::path path(configuration.filterDir);
   if (std::filesystem::exists(path)) {
-    parseConfig();
     // run the transformer on the file structure
     int result = transformAll(path, 0);
     std::cout << "Number of Compilable Benchmarks: " << result << std::endl;

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -220,7 +220,7 @@ void Transformer::parseConfig(std::string configFile) {
   }
   if (file.is_open()) {
     std::cout << "Using: " << configFile << " Specified Settings" << std::endl;
-    std::regex pattern("^\\s*(\\w+)\\s*=\\s*([0-9]+|[\\w\\s,]+)$");
+    std::regex pattern("^\\s*(\\w+)\\s*=\\s*([0-9]+|[\\w\\s,]+|[\\w/-_.]+)$");
     std::string line;
     std::smatch match;
     while (std::getline(file, line)) {

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -17,7 +17,6 @@
 #include <clang/Tooling/CommonOptionsParser.h>
 #include <clang/Tooling/Tooling.h>
 #include <cstring>
-#include <filesystem>
 #include <fstream>
 #include <llvm/ADT/IntrusiveRefCntPtr.h>
 #include <llvm/ADT/StringRef.h>
@@ -27,7 +26,6 @@
 #include <llvm/Support/raw_ostream.h>
 #include <memory>
 #include <regex>
-#include <string>
 #include <vector>
 
 Transformer::Transformer(std::string configFile) : configuration() {
@@ -122,8 +120,10 @@ bool Transformer::transformFile(std::filesystem::path path) {
 
   output.close();
 
-  if (!checkCompilable(srcPath)) { // TODO implement && !configs->keepCompilesOnly) {
-    // std::filesystem::remove(srcPath); // TODO this can be uses later for keeping only those that compile
+  if (!checkCompilable(srcPath)) {
+    if (!configuration.keepCompilesOnly) {
+      std::filesystem::remove(srcPath);
+    }
     return 0;
   }
 
@@ -211,6 +211,7 @@ int Transformer::checkCompilable(std::filesystem::path path) {
   return 1;
 }
 
+/// TODO MAKE THE PARSERS MORE SECURE!!
 void Transformer::parseConfig(std::string configFile) {
   std::ifstream file(configFile);
   if (!std::filesystem::exists(configFile)) {

--- a/src/transform/include/Transformer.hpp
+++ b/src/transform/include/Transformer.hpp
@@ -2,10 +2,19 @@
 
 #include <filesystem>
 #include <string>
-#include <vector>
+
+struct transformConfigs {
+  int debugLevel;
+  bool keepCompilesOnly;
+  std::string filterDir;
+  std::string benchmarkDir;
+};
 
 class Transformer {
 public:
+  /// Constructor
+  Transformer(std::string configFile);
+
   /// Creates the frontend action to transform a file
   bool transformFile(std::filesystem::path path);
 
@@ -15,29 +24,17 @@ public:
   /// Check that the transformed file compiles without errors
   int checkCompilable(std::filesystem::path path);
 
-  /// Parses the configuration file to determine necessary types and counts and
-  /// location of files
-  void parseConfig();
+  /// Parses the configuration file to determine location of files to filter
+  /// where to store benchmarks
+  /// what the debug level is
+  /// whether or not to keep benchmarks that do not compile
+  void parseConfig(std::string configFile);
 
   /// Driver for the transformer that is called by full or transform to run the
   /// transformer on code specified by the given arguments
-  int run(std::string filePath = "filteredFiles");
+  int run();
 
 private:
-  struct configs {
-    int minLoC;
-    int maxLoC;
-    int minIf;
-    int maxLoop;
-    int minLoop;
-    int minNumCompareInt;
-    int minNumOpBinary;
-    int minNumOpUnary;
-    int minNumVarInt;
-    int maxNumVarFloat;
-    int maxNumVarString;
-    int maxNumVarPoint;
-    int maxNumVarStruct;
-    int keepCompilesOnly;
-  };
+  // std::filesystem::path _ConfigFile;
+  struct transformConfigs configuration;
 };

--- a/src/transform/main.cpp
+++ b/src/transform/main.cpp
@@ -4,14 +4,14 @@
 /// Main function should be transfered to a driver for use via the full implementation
 int main(int argc, char** argv) {
   if (argc == 2) {
-    Transformer transformer;
-    transformer.run(argv[1]);
+    Transformer transformer(argv[1]);
+    transformer.run();
   } else if (argc > 1 ) {
-    Transformer transformer;
-    transformer.run(argv[1]);
+    Transformer transformer(argv[1]);
+    transformer.run();
   }else {
     std::cout << "Incorrect Number of Args" << std::endl;
-    std::cout << "Please Give the Location of the File or Directory to Transform";
+    std::cout << "Please Give the Location of the Configuration File" << std::endl;
   }
   return 1;
 }

--- a/test.config
+++ b/test.config
@@ -1,0 +1,38 @@
+[File Locations]
+csv=dataset.csv
+databaseDir=samples/Tester/
+filterDir=filteredFiles
+benchmarkDir=benchmarks
+
+[Downloading]
+language = C
+projectCount = 15
+minNumStars=0
+minActivity=0
+minRepoLoc=100
+maxRepoLoc=10000
+
+
+[Function Requirements]
+maxForLoops = 9999
+minTypeCompareOperation = 0
+minTypeIfStmt = 0
+minTypeArithmeticOperation = 1
+
+[File Requirements and Settings]
+# type = Int string Bool
+# Leave out Type in order to filter for any type
+type=Int
+minFileLoC=0
+maxFileLoC=9999
+useNonStdHeaders=false
+keepCompilesOnly=false
+
+[Debugging Flags]
+debug=false
+# debug level:
+# 0 for no debugging, increase number to inlcude more and more debugging messages
+# 1 for High priority debugging only
+# 2 for Mid  priority debugging and above
+# 3 for Low  priority debugging and above
+debugLevel=0

--- a/testRun.sh
+++ b/testRun.sh
@@ -1,7 +1,4 @@
 #!/bin/sh
-
-python3 ./src/download/Downloader.py
-
 set -e
 
 echo "=================================== CMake ==================================="
@@ -20,14 +17,14 @@ rm -r filteredFiles/*
 rm -r preprocessed/*
 rm -r benchmark/*
 
-# set -e
+set -e
 
 echo "=================================== Using Resources ==================================="
 clangResourceDir="$(clang -print-resource-dir)"
 echo "Using Resource Directory: $clangResourceDir"
 
 echo "=================================== Run Filter ==================================="
-./build/filter properties.config
+./build/filter test.config
 
 echo "=================================== Run Transform ==================================="
-./build/transform properties.config
+./build/transform test.config


### PR DESCRIPTION
# Updates

Minor fixes for consistency and flexibility in the program before V0.0.0 release and July holdiay.

## Interface

- Change command line args to just the config file
    - All other settings come through the config file and the environment variable set
-  Scripts updated to use new command line args
    - `run.sh` and `liveRun.sh` now take a config file as an arg as to be more versatile
    - 'testRun.sh` and `onlineRun.sh` remain hard coded for testing purposes
- Additional sample configs provided 

## Fixes

- Add fix to exit cleanly on environment variable not set rather than crash
- Downloader no longer creates unneeded file that was previously not cleaned up
- Downloader concatenates paths properly rather than by string, should fix error on windows

## Features

- Code now supports Config File Setting: keepCompilesOnly to delete all non compiling benchmarks during the run
- Downloader now takes a config file as an argument rather than the hard coded practice one
- Downloader now filters based on stars as well (more updates needed)
- Config file now specifies the filtered files location
- Config file now specifies the database location
- Additional config parsing capabilities/infrastructure added for debugger and other later development

## Documentation

- README updated

## Related Issues

- #22 
- #29
- #30
- #18