### PR TITLE
Hotfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,23 +29,6 @@ find_package(LLVM REQUIRED)
 # Can be used to enforce downloader to run before filter?
 # add_dependencies(filter download)
 
-file(GLOB_RECURSE MANUAL_FILES "manual/*.c"
-  # ./manual/round2/CheckBigBitfield.c
-  # ./manual/round2/TestQnanhibit.c
-  # ./manual/round2/calcnewt.c
-  # ./manual/round2/dehex.c
-  # ./manual/round2/enhex.c
-  # ./manual/round2/fastjson.c
-  # ./manual/round2/getdelim.c
-  # ./manual/round2/getdelimog.c
-  # ./manual/round2/mt19937-64.c
-  # ./manual/round2/mt19937ar.c
-  # ./manual/round2/sorts.c
-)
-
-add_library(sample_c_files OBJECT ${MANUAL_FILES})
-target_compile_features(sample_c_files PRIVATE c_std_99)
-
 set(HEADERS_FILTER
   src/filter/include
 )

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -284,10 +284,9 @@ int Filterer::run() {
       std::vector<std::string> args = std::vector<std::string>({
         "clang",
         "-extra-arg=-xc",
-        "-extra-arg=-I",
-        oldPath.string(),
         "-extra-arg=-resource-dir=" + resourceDir,
         "-extra-arg=-fparse-all-comments",
+        oldPath.string(),
         // "-extra-arg=-Wdocumentation",
       });
 

--- a/src/transform/ReplaceDeadCallsVisitor.cpp
+++ b/src/transform/ReplaceDeadCallsVisitor.cpp
@@ -50,7 +50,7 @@ bool ReplaceDeadCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
                 newReturnType = _C->VoidPtrTy;
                 myType = "void*";
                 newReturnTypeName = "pointer";
-              }else {
+              } else {
                 for (unsigned i=0; i<returnTypeName.size(); i++) {
                   char letter = returnTypeName[i];
                   if (letter == ' ') {
@@ -64,10 +64,7 @@ bool ReplaceDeadCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
                   } 
                 }
               }
-              // If the return value is a pointer it needs to be cast to the original return type
-              isPointer ? newName += "(" + returnTypeName + ")(" : newName;
               newName += "__VERIFIER_nondet_" + newReturnTypeName + "()";
-              isPointer ? newName += ")" : newName;
               clang::SourceRange range;
               range.setBegin(E->getBeginLoc());
               range.setEnd(E->getEndLoc());
@@ -87,7 +84,6 @@ bool ReplaceDeadCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
                 E->getExprLoc().getLocWithOffset(1),
                 funcName,
                 refDecl->getReturnType(),
-                // returnType,
                 _C->CreateTypeSourceInfo(_C->VoidTy),
                 clang::SC_Extern
               );
@@ -97,10 +93,8 @@ bool ReplaceDeadCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
                 // Use a stringstream and string to take advantage of the built in print to string functionality
                 std::string verifierString = "";
                 llvm::raw_string_ostream tempStream(verifierString);
-                // Add any needed components for casting pointers
-                isPointer ? verifierString += "(" + newReturnTypeName + ")(" : verifierString;
                 newFunction->printName(tempStream);
-                isPointer ? verifierString += "())" : verifierString += "()";
+                verifierString += "()";
                 llvm::outs() << verifierString << " - The String for Replace Dead Calls Visitor\n";
                 _Rewriter.ReplaceText(E->getSourceRange(), verifierString);
                 llvm::outs() << "Inserted the text\n";

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -90,10 +90,9 @@ bool Transformer::transformFile(std::filesystem::path path) {
   std::vector<std::string> compOptionsArgs({
     "clang",
     "-extra-arg=-xc",
-    "-extra-arg=-I",
-    path.string(),
     "-extra-arg=-resource-dir=" + resourceDir,
     "-extra-arg=-fparse-all-comments",
+    path.string(),
   });
 
   int argc = compOptionsArgs.size();
@@ -191,10 +190,9 @@ int Transformer::checkCompilable(std::filesystem::path path) {
     "clang",
     "-extra-arg=-fsyntax-only",
     "-extra-arg=-xc",
-    "-extra-arg=-I",
     "-extra-arg=-resource-dir=" + resourceDir,
-    "verifier.c", // dummy verify file is needed to resolve extern Verifier Functions
     path.string(),
+    "verifier.c", // dummy verify file is needed to resolve extern Verifier Functions
   });
 
   int argc = compOptionsArgs.size();


### PR DESCRIPTION
Some code was incorrectly reverted during the merge and now wrong arguments are being passed to clang when generating the AST causing booleans to break and benchmarks to not compile.

Hot fix removes faulty arguments. Fixes Build system to allow the program to compile with cmake correctly. Slight change in pointer logic.
