### PR TITLE
Fixes/natsteven/fixes before v0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ filtered-files/
 source-files/
 transformed-files/
 ARG-V_Survey_Report.html
+repos-filtered/
+repos-transformed/
 
 ## IDEs
 .idea/

--- a/Design.md
+++ b/Design.md
@@ -98,13 +98,27 @@ Turns filtered files into self-contained, intraprocedural SV-Comp benchmarks.
   __VERIFIER_nondet_<suffix>(void);` lines are inserted for every suffix used (skipping
   ones the Filter stage already injected). Helper definitions for `__havoc_block` and
   `__havoc_cstring` are emitted when those markers are present.
+- **Standard-header injection** (`AddStdIncludesConsumer`): include stripping (below)
+  also drops the project headers through which standard types like `size_t`, `bool`,
+  `FILE`, or `uint32_t` were transitively available. This consumer walks the AST for
+  used types, maps each to its standard header via
+  `src/common/include/StdHeaders.hpp` (a type→header registry with categories for
+  future logical-structure filtering), and re-injects any needed `#include <...>` not
+  already present.
 - **Post-processing** (`Transformer::transformFile`):
   - **Empty-harness discard**: if the generated `main` contains no function calls (every
     function was skipped), the output file is unconditionally deleted
   - **Compile check**: the output is compiled with `clang -fsyntax-only` alongside
     `verifier.c`; non-compiling benchmarks are deleted when `keepCompilesOnly` is set
+  - **Preprocessing**: surviving benchmarks are preprocessed into a `.i` file with
+    `gcc -E -P -std=gnu11` (the form SV-Comp consumes); on failure the `.c`/`.yml`/`.i`
+    are removed
 - Emits `.c` + `.yml` task files into `benchmarkDir`; `.set` files in
   `argc-benchmarks/` group `.yml` files into SV-Comp benchmark sets.
+- **Crash isolation** (`Transformer::transformFileIsolated`): each file's transform runs
+  in a forked child, so a segfault, OOM-kill, assertion, or hang on one pathological file
+  cannot halt the whole batch. The parent enforces a per-file `fileTimeoutSecs` budget
+  (default 60s), kills overruns, cleans up any partial output, and continues.
 
 ## Design Choices and Limitations
 
@@ -162,8 +176,10 @@ operations on the result stay in bounds. Function pointer returns are left as-is
 
 The Transform step removes all non-system `#include` directives. Functions declared in
 project-local headers are havocked anyway, so the includes only leave unresolvable
-references. Files that depend on types or macros from a local header will fail to compile
-after stripping and are caught by `keepCompilesOnly`.
+references. Standard types that were reaching the file transitively through a stripped
+project header are recovered by `AddStdIncludesConsumer` (see the Transform stage above).
+Files that depend on *project* types or macros from a local header will still fail to
+compile after stripping and are caught by `keepCompilesOnly`.
 
 ### Preprocessor-Gated Code
 
@@ -225,7 +241,8 @@ flowchart TB
         T1["HavocCallsConsumer<br/>havoc in-file calls, record suffixes"]
         T2["MainGenConsumer<br/>rename main, synthesize int main(void)"]
         T3["AddVerifiersConsumer<br/>insert extern nondet decls"]
-        T1 --> T2 --> T3
+        T4["AddStdIncludesConsumer<br/>re-inject needed standard headers"]
+        T1 --> T2 --> T3 --> T4
     end
 
     MUX --> filterC

--- a/README.md
+++ b/README.md
@@ -128,5 +128,8 @@ Key sections:
 
 - `[File Locations]` — `databaseDir`, `filterDir`, `benchmarkDir`
 - `[Function Requirements]` — per-function thresholds (`minForLoops`, `minTypeIfStmt`, etc.)
-- `[File Requirements and Settings]` — `type`, `minFileLoC`, `useNonStdHeaders`, `keepCompilesOnly`
+- `[File Requirements and Settings]` — `type`, `minFileLoC`, `useNonStdHeaders`, `keepCompilesOnly`, `fileTimeoutSecs`
 - `[Debugging Flags]` — `debug`, `debugLevel` (0–3)
+
+The transform stage preprocesses each surviving benchmark into a `.i` file with
+`gcc -E -P -std=gnu11`, requiring `gcc` on `PATH`.

--- a/properties.config
+++ b/properties.config
@@ -17,9 +17,9 @@ downloadDir=database
 # breaks on absolute paths.
 databaseDir=source-files
 # Output of filter / input of transform
-filterDir=filtered-files
+filterDir=repos-filtered
 # Output of transform
-benchmarkDir=transformed-files
+benchmarkDir=repos-transformed
 
 [Downloading]
 # Downloader.py only
@@ -68,10 +68,10 @@ useNonStdHeaders=true
 # Transform step: delete generated benchmarks that fail a clang syntax check
 # against verifier.c. Defaults to true; disable while debugging or failing
 # outputs vanish silently.
-keepCompilesOnly=false
+keepCompilesOnly=true
 # Parsed but not yet implemented (cleanup is handled by scripts):
 # wipeOldBenchmarks=true
 
 [Debugging Flags]
 # 0 = silent, 1 = high-priority messages, 2 = +per-file detail, 3 = everything
-debugLevel=0
+debugLevel=1

--- a/properties.config
+++ b/properties.config
@@ -12,9 +12,8 @@
 # Downloader.py only: CSV listing candidate repos, and where to clone them
 csv=dataset-filtered.csv
 downloadDir=database
-# Input tree of C files for the filter step. Keep paths relative and run from
-# the repo root: the output-path mirroring strips components by name and
-# breaks on absolute paths.
+# Input tree of C files for the filter step. Absolute and relative paths both
+# work; relative paths are resolved against the working directory.
 databaseDir=source-files
 # Output of filter / input of transform
 filterDir=repos-filtered

--- a/src/common/include/ClangToolUtils.hpp
+++ b/src/common/include/ClangToolUtils.hpp
@@ -12,11 +12,18 @@
 #include <string>
 #include <vector>
 
+/**
+ * @brief Aborts the process when built against an unsupported Clang.
+ *
+ * LLVM 20 is the minimum; older versions miss APIs this project relies on and
+ * have produced AST-traversal crashes. Newer versions are accepted.
+ */
 inline void checkClangVersion() {
-  if (CLANG_VERSION_MAJOR != 20) {
-    std::cerr << "Warning: built against Clang " << CLANG_VERSION_STRING
-              << ", expected Clang 20. Rebuild with the correct LLVM version."
-              << "Specify Clang version for Cmake per README.md" << std::endl;
+  if (CLANG_VERSION_MAJOR < 20) {
+    std::cerr << "Error: built against Clang " << CLANG_VERSION_STRING
+              << ", but Clang 20 or newer is required. "
+              << "Specify the Clang version for CMake per README.md." << std::endl;
+    std::exit(1);
   }
 }
 

--- a/src/common/include/ClangToolUtils.hpp
+++ b/src/common/include/ClangToolUtils.hpp
@@ -1,14 +1,24 @@
 #pragma once
 
+#include <clang/Basic/Version.h>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <map>
 #include <optional>
 #include <regex>
 #include <string>
 #include <vector>
+
+inline void checkClangVersion() {
+  if (CLANG_VERSION_MAJOR != 20) {
+    std::cerr << "Warning: built against Clang " << CLANG_VERSION_STRING
+              << ", expected Clang 20. Rebuild with the correct LLVM version."
+              << "Specify Clang version for Cmake per README.md" << std::endl;
+  }
+}
 
 /**
  * @brief Returns the macOS SDK sysroot, if applicable.

--- a/src/common/include/DebugLog.hpp
+++ b/src/common/include/DebugLog.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+
+/**
+ * @file DebugLog.hpp
+ * @brief Process-global verbosity for log gating.
+ *
+ * Set once from the config's {@code debugLevel}. Consumers buried deep in the
+ * Clang chain (and the forked transform children, which inherit the value)
+ * read it without threading {@code debugLevel} through every layer.
+ *
+ * Levels: 0 silent (summary + real errors only), 1 per-file progress,
+ * 2 per-function decisions, 3 everything.
+ */
+/**
+ * @brief Accessor for the process-global verbosity level.
+ *
+ * @return A reference to the level, so callers can read or set it.
+ */
+inline int &globalDebugLevel() {
+  static int level = 0;
+  return level;
+}
+
+/**
+ * @brief Writes a message to stderr, gated on the global verbosity level.
+ *
+ * @param level Minimum verbosity at which {@code msg} should be printed.
+ * @param msg   The message to write (a newline is appended).
+ */
+inline void debugLog(int level, const std::string &msg) {
+  if (globalDebugLevel() >= level)
+    std::cerr << msg << std::endl;
+}

--- a/src/common/include/StdHeaders.hpp
+++ b/src/common/include/StdHeaders.hpp
@@ -1,10 +1,24 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+/**
+ * @file StdHeaders.hpp
+ * @brief Registry mapping standard/POSIX type names to their defining headers.
+ *
+ * Used by the transform step to re-inject the standard headers that include
+ * stripping leaves missing. Each entry also carries a {@code HeaderCategory} so
+ * future passes can filter benchmarks by logical structure (concurrency, file
+ * I/O, etc.).
+ */
+
+/**
+ * @brief Logical grouping for a standard header, for future structure-based filtering.
+ */
 enum class HeaderCategory {
   Core,
   IO,
@@ -15,11 +29,17 @@ enum class HeaderCategory {
   Time,
 };
 
+/**
+ * @brief A standard type's defining header together with its logical category.
+ */
 struct StdHeaderInfo {
-  std::string header;
-  HeaderCategory category;
+  std::string header;       ///< Header that defines the type (e.g. "stdint.h").
+  HeaderCategory category;  ///< Logical grouping of the header.
 };
 
+/**
+ * @brief Maps a standard/POSIX type name to the header that defines it.
+ */
 inline const std::unordered_map<std::string, StdHeaderInfo> kStdTypeHeaders = {
     // <stdbool.h>
     {"bool", {"stdbool.h", HeaderCategory::Core}},
@@ -139,6 +159,12 @@ inline const std::unordered_map<std::string, StdHeaderInfo> kStdTypeHeaders = {
     {"stat", {"sys/stat.h", HeaderCategory::IO}},
 };
 
+/**
+ * @brief Looks up the header and category for a standard type name.
+ *
+ * @param typeName Type name as spelled in source (e.g. "size_t").
+ * @return The header/category info, or std::nullopt if the type is not standard.
+ */
 inline std::optional<StdHeaderInfo> stdHeaderForType(const std::string &typeName) {
   auto it = kStdTypeHeaders.find(typeName);
   if (it == kStdTypeHeaders.end())
@@ -146,6 +172,12 @@ inline std::optional<StdHeaderInfo> stdHeaderForType(const std::string &typeName
   return it->second;
 }
 
+/**
+ * @brief Returns the set of headers belonging to a logical category.
+ *
+ * @param cat Category to collect headers for.
+ * @return All distinct header names whose entries are tagged with {@code cat}.
+ */
 inline std::unordered_set<std::string> headersForCategory(HeaderCategory cat) {
   std::unordered_set<std::string> result;
   for (const auto &[type, info] : kStdTypeHeaders) {

--- a/src/common/include/VerifierNames.hpp
+++ b/src/common/include/VerifierNames.hpp
@@ -11,9 +11,12 @@
  *
  */
 
-/// Canonical mapping from Clang builtin type kind to SV-Comp verifier suffix.
-/// Types not in this map are unsupported (e.g. pointers, structs) and callers
-/// should skip them.
+/**
+ * @brief Canonical mapping from Clang builtin type kind to SV-Comp verifier suffix.
+ *
+ * Types not in this map are unsupported (e.g. pointers, structs) and callers
+ * should skip them.
+ */
 inline const std::unordered_map<clang::BuiltinType::Kind, std::string> kVerifierNames = {
     {clang::BuiltinType::Bool, "bool"},           {clang::BuiltinType::Char_S, "char"},
     {clang::BuiltinType::Char_U, "char"},         {clang::BuiltinType::SChar, "char"},
@@ -25,8 +28,10 @@ inline const std::unordered_map<clang::BuiltinType::Kind, std::string> kVerifier
     {clang::BuiltinType::Double, "double"},
 };
 
-/// Maps verifier suffix to the C type spelling used in source-level
-/// declarations (e.g. "uint" -> "unsigned int").
+/**
+ * @brief Maps verifier suffix to the C type spelling used in source-level
+ * declarations (e.g. "uint" -> "unsigned int").
+ */
 inline const std::unordered_map<std::string, std::string> kVerifierCTypes = {
     {"bool", "_Bool"},
     {"char", "char"},
@@ -43,8 +48,12 @@ inline const std::unordered_map<std::string, std::string> kVerifierCTypes = {
     {"double", "double"},
 };
 
-/// Returns the C type spelling for a verifier suffix (e.g. "unsigned int"
-/// for "uint"), or std::nullopt if the suffix is unknown.
+/**
+ * @brief Returns the C type spelling for a verifier suffix.
+ *
+ * @param suffix Verifier suffix (e.g. "uint").
+ * @return The C type spelling (e.g. "unsigned int"), or std::nullopt if unknown.
+ */
 inline std::optional<std::string> cTypeForSuffix(const std::string &suffix) {
   auto it = kVerifierCTypes.find(suffix);
   if (it == kVerifierCTypes.end())
@@ -52,8 +61,12 @@ inline std::optional<std::string> cTypeForSuffix(const std::string &suffix) {
   return it->second;
 }
 
-/// Returns the verifier suffix for a type (e.g. "uint" for `unsigned int`),
-/// or std::nullopt if the type is not a supported builtin.
+/**
+ * @brief Returns the verifier suffix for a type.
+ *
+ * @param QT The type to resolve (e.g. `unsigned int`).
+ * @return The suffix (e.g. "uint"), or std::nullopt if not a supported builtin.
+ */
 inline std::optional<std::string> verifierSuffixForType(clang::QualType QT) {
   // A null type comes back from error-recovery AST nodes (e.g. calls or
   // params built from undefined macros when headers are missing).
@@ -68,8 +81,12 @@ inline std::optional<std::string> verifierSuffixForType(clang::QualType QT) {
   return it->second;
 }
 
-/// Returns the full verifier function name for a type
-/// (e.g. "__VERIFIER_nondet_uint"), or std::nullopt if unsupported.
+/**
+ * @brief Returns the full verifier function name for a type.
+ *
+ * @param QT The type to resolve.
+ * @return The name (e.g. "__VERIFIER_nondet_uint"), or std::nullopt if unsupported.
+ */
 inline std::optional<std::string> verifierFnNameForType(clang::QualType QT) {
   std::optional<std::string> suffix = verifierSuffixForType(QT);
   if (!suffix)

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -1,6 +1,7 @@
 #include "include/Filterer.hpp"
 #include "FrontendFactoryWithArgs.hpp"
 #include "ClangToolUtils.hpp"
+#include "DebugLog.hpp"
 
 #include <algorithm>
 #include <clang/AST/Type.h>
@@ -91,14 +92,15 @@ void Filterer::parseConfigFile(std::string configFile) {
     }
   }
 
-  if (config.at("debugLevel") >= 1) {
-    std::cout << "[filter] loaded config: " << configFile << std::endl;
-    for (const auto &[k, v] : config) {
-      std::cout << "  " << k << " = " << v << std::endl;
-    }
-    for (const std::string &t : typeNames) {
-      std::cout << "  type: " << t << std::endl;
-    }
+  globalDebugLevel() = config.at("debugLevel");
+
+  if (globalDebugLevel() >= 1) {
+    std::string dump = "[filter] loaded config: " + configFile;
+    for (const auto &[k, v] : config)
+      dump += "\n  " + k + " = " + std::to_string(v);
+    for (const std::string &t : typeNames)
+      dump += "\n  type: " + t;
+    debugLog(1, dump);
   }
 }
 
@@ -117,11 +119,9 @@ bool Filterer::checkPotentialFile(std::string fileName) {
             std::find(stdLibNames.begin(), stdLibNames.end(), match[2]) != stdLibNames.end();
         if (!isStdLib && !config.at("useNonStdHeaders")) {
           file.close();
-          if (config.at("debugLevel") >= 1) {
-            std::cout << "[filter] skipped (non-std header '" << match[2].str()
-                      << "', useNonStdHeaders=" << config.at("useNonStdHeaders") << "): " << fileName
-                      << std::endl;
-          }
+          debugLog(1, "[filter] skipped (non-std header '" + match[2].str() +
+                          "', useNonStdHeaders=" + std::to_string(config.at("useNonStdHeaders")) +
+                          "): " + fileName);
           return false;
         }
       }
@@ -132,16 +132,12 @@ bool Filterer::checkPotentialFile(std::string fileName) {
     }
     file.close();
     if (count < config.at("minFileLoC")) {
-      if (config.at("debugLevel") >= 1) {
-        std::cout << "[filter] skipped (LoC " << count << " < minFileLoC " << config.at("minFileLoC")
-                  << "): " << fileName << std::endl;
-      }
+      debugLog(1, "[filter] skipped (LoC " + std::to_string(count) + " < minFileLoC " +
+                      std::to_string(config.at("minFileLoC")) + "): " + fileName);
       return false;
     } else if (count > config.at("maxFileLoC")) {
-      if (config.at("debugLevel") >= 1) {
-        std::cout << "[filter] skipped (LoC " << count << " > maxFileLoC " << config.at("maxFileLoC")
-                  << "): " << fileName << std::endl;
-      }
+      debugLog(1, "[filter] skipped (LoC " + std::to_string(count) + " > maxFileLoC " +
+                      std::to_string(config.at("maxFileLoC")) + "): " + fileName);
       return false;
     } else {
       return true;
@@ -155,30 +151,21 @@ bool Filterer::checkPotentialFile(std::string fileName) {
 int Filterer::getAllCFiles(std::filesystem::path pathObject,
                            std::vector<std::string> &filesToFilter, int numFiles) {
   if (!std::filesystem::exists(pathObject)) {
-    if (config.at("debugLevel") >= 2) {
-      std::cout << "[filter] path does not exist: " << pathObject.string() << std::endl;
-    }
+    debugLog(2, "[filter] path does not exist: " + pathObject.string());
     return 0;
   }
   if (std::filesystem::is_regular_file(pathObject)) {
     if (pathObject.has_extension()) {
       if (pathObject.extension() == ".c") {
-        if (config.at("debugLevel") >= 2) {
-          std::cout << "[filter] queued: " << pathObject.filename().string() << std::endl;
-        }
+        debugLog(2, "[filter] queued: " + pathObject.filename().string());
         filesToFilter.push_back(pathObject.string());
         return 1;
       } else {
-        if (config.at("debugLevel") >= 3) {
-          std::cout << "[filter] skipped (not .c): " << pathObject.filename().string() << std::endl;
-        }
+        debugLog(3, "[filter] skipped (not .c): " + pathObject.filename().string());
         return 0;
       }
     } else {
-      if (config.at("debugLevel") >= 3) {
-        std::cout << "[filter] skipped (no extension): " << pathObject.filename().string()
-                  << std::endl;
-      }
+      debugLog(3, "[filter] skipped (no extension): " + pathObject.filename().string());
       return 0;
     }
   } else if (std::filesystem::is_directory(pathObject)) {
@@ -188,42 +175,42 @@ int Filterer::getAllCFiles(std::filesystem::path pathObject,
     }
     return numFiles;
   } else {
-    if (config.at("debugLevel") >= 3) {
-      std::cout << "[filter] ignored: " << pathObject.filename().string() << std::endl;
-    }
+    debugLog(3, "[filter] ignored: " + pathObject.filename().string());
     return 0;
   }
   return 0;
 }
 
-void Filterer::debugInfo(std::string info) {
-  if (config.at("debugLevel") > 0) {
-    std::cout << "[filter] " << info << std::endl;
-  }
-}
+void Filterer::debugInfo(std::string info) { debugLog(1, "[filter] " + info); }
 
 /// Main driver for the Filter System
 int Filterer::run() {
   std::filesystem::path pathObject(configuration.databaseDir);
   std::vector<std::string> filesToFilter = std::vector<std::string>();
 
-  if (config.at("debugLevel") >= 1) {
-    std::cout << "[filter] scanning: " << pathObject.string() << std::endl;
-  }
+  debugLog(1, "[filter] scanning: " + pathObject.string());
 
   int filesFound = getAllCFiles(pathObject, filesToFilter, 0);
-  if (config.at("debugLevel") >= 1) {
-    std::cout << "[filter] found " << filesFound << " .c file(s)" << std::endl;
-  }
+  debugLog(1, "[filter] found " + std::to_string(filesFound) + " .c file(s)");
 
+  int passed = 0;
   for (std::string fileName : filesToFilter) {
     if (checkPotentialFile(fileName)) {
+      passed++;
       std::filesystem::path oldPath(fileName);
-      std::filesystem::path newPath(std::filesystem::current_path() / configuration.filterDir);
-      for (const std::filesystem::path &component : oldPath) {
-        if (component.string() != ".." && component.string() != configuration.databaseDir) {
-          newPath /= component;
-        }
+      // Mirror the input's path under filterDir by stripping the databaseDir
+      // prefix; relative() handles absolute and relative inputs uniformly.
+      std::filesystem::path relPath =
+          std::filesystem::relative(oldPath, configuration.databaseDir);
+      if (relPath.empty() || *relPath.begin() == "..")
+        relPath = oldPath.filename();
+      std::filesystem::path newPath = std::filesystem::path(configuration.filterDir) / relPath;
+
+      // Hard guard: never write over the source, whatever the path arithmetic.
+      if (std::filesystem::weakly_canonical(oldPath) ==
+          std::filesystem::weakly_canonical(newPath)) {
+        std::cerr << "Refusing to overwrite source file: " << oldPath.string() << std::endl;
+        continue;
       }
 
       static llvm::cl::OptionCategory myToolCategory("filterer");
@@ -261,20 +248,24 @@ int Filterer::run() {
       FrontendFactoryWithArgs factory(&config, typesRequested, output);
 
       int result = tool.run(&factory);
-      if (config.at("debugLevel") >= 2) {
-        std::cout << "[filter] tool result for " << fileName << ": " << result << std::endl;
-      }
+      debugLog(2, "[filter] tool result for " + fileName + ": " + std::to_string(result));
 
       output.close();
 
-      if (config.at("debugLevel") >= 2 && std::filesystem::exists(newPath)) {
+      if (globalDebugLevel() >= 2 && std::filesystem::exists(newPath)) {
         std::ifstream outFile(newPath.string());
         if (outFile.is_open()) {
-          std::cout << "[filter] output for " << newPath.string() << ":\n"
-                    << outFile.rdbuf() << std::endl;
+          std::stringstream contents;
+          contents << outFile.rdbuf();
+          debugLog(2, "[filter] output for " + newPath.string() + ":\n" + contents.str());
         }
       }
     }
   }
+
+  std::cout << "\n=== Filter summary ===\n"
+            << "  Files found:            " << filesFound << "\n"
+            << "  Passed pre-filter:      " << passed << "\n"
+            << "  Skipped:                " << (filesFound - passed) << std::endl;
   return 0;
 }

--- a/src/filter/main.cpp
+++ b/src/filter/main.cpp
@@ -1,8 +1,10 @@
 #include "include/Filterer.hpp"
+#include "ClangToolUtils.hpp"
 #include <iostream>
 
 // Target for calling the Filterer Individually
 int main(int argc, char **argv) {
+  checkClangVersion();
   if (argc == 2) {
     Filterer filter(argv[1]);
     filter.run();

--- a/src/full/main.cpp
+++ b/src/full/main.cpp
@@ -1,9 +1,11 @@
 #include "Filterer.hpp"
 #include "Transformer.hpp"
+#include "ClangToolUtils.hpp"
 #include <iostream>
 
 // TODO OVER HAUL THIS WHOLE THING TO MAKE SENSE AGAIN
 int main(int argc, char **argv) {
+  checkClangVersion();
   if (argc == 4) {
     Filterer filter(argv[1]);
     filter.run();

--- a/src/transform/HavocCallsVisitor.cpp
+++ b/src/transform/HavocCallsVisitor.cpp
@@ -49,9 +49,7 @@ bool HavocCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
   }
 
   clang::QualType returnType = E->getCallReturnType(*_C);
-  // A null return type can come back for calls whose callee type can't be
-  // resolved to a FunctionType (e.g. macro-expanded)
-  if (returnType.isNull())
+  if (returnType.isNull() || returnType.getTypePtrOrNull() == nullptr)
     return clang::RecursiveASTVisitor<HavocCallsVisitor>::VisitCallExpr(E);
   if (returnType->isVoidType()) {
     // A void call yields no value to havoc; drop it (the statement's

--- a/src/transform/MainGenConsumer.cpp
+++ b/src/transform/MainGenConsumer.cpp
@@ -1,5 +1,6 @@
 #include "MainGenConsumer.hpp"
 
+#include "DebugLog.hpp"
 #include "VerifierNames.hpp"
 
 #include <clang/AST/Decl.h>
@@ -9,7 +10,6 @@
 #include <optional>
 #include <string>
 #include <vector>
-#include <iostream>
 
 MainGenConsumer::MainGenConsumer(std::shared_ptr<std::set<std::string>> neededSuffixes,
                                  clang::Rewriter &rewriter)
@@ -42,9 +42,8 @@ void MainGenConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
       continue;
     }
     if (func->isVariadic()) {
-      std::cout << "Warning: variadic functions unsupported\n" + func->getNameAsString() +
-                       " not harnessed"
-                << std::endl;
+      debugLog(2, "Warning: variadic functions unsupported; " + func->getNameAsString() +
+                      " not harnessed");
       continue;
     }
     std::string args;
@@ -64,9 +63,8 @@ void MainGenConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
     // A parameter without a nondet equivalent (pointer, struct, ...): skip
     // this function but keep harnessing the rest.
     if (!supported) {
-      std::cout << "Warning: only primitive symbolics supported\n" + func->getNameAsString() +
-                       " not harnessed (filter's param check did not strip it)"
-                << std::endl;
+      debugLog(2, "Warning: only primitive symbolics supported; " + func->getNameAsString() +
+                      " not harnessed (filter's param check did not strip it)");
       continue;
     }
     std::string name = func->isMain() ? "original_main" : func->getNameAsString();

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -176,56 +176,24 @@ void reach_error(void) {}
 )";
 
 int Transformer::checkCompilable(std::filesystem::path path) {
-  static llvm::cl::OptionCategory myToolCategory("CheckCompiles");
-
   std::optional<std::string> resourceDir = getResourceDir();
-  if (!resourceDir) {
+  if (!resourceDir)
     return 0;
-  }
 
-  // Write embedded verifier stubs to a temp file next to the benchmark
   std::filesystem::path verifierPath = path.parent_path() / "__verifier_stubs.c";
   {
     std::ofstream out(verifierPath);
     out << kVerifierStubs;
   }
 
-  std::vector<std::string> args({
-      "clang",
-      "-extra-arg=-fsyntax-only",
-      "-extra-arg=-xc",
-      "-extra-arg=-resource-dir=" + *resourceDir,
-  });
+  std::string cmd = "clang -fsyntax-only -xc"
+                    " -resource-dir=" + *resourceDir;
   std::optional<std::string> sysroot = getSysroot();
-  if (sysroot) {
-    args.push_back("-extra-arg=-isysroot");
-    args.push_back("-extra-arg=" + *sysroot);
-  }
-  args.push_back(path.string());
-  args.push_back(verifierPath.string());
-  std::vector<const char *> argv = toArgv(args);
-  int argc = static_cast<int>(args.size());
+  if (sysroot)
+    cmd += " -isysroot " + *sysroot;
+  cmd += " " + path.string() + " " + verifierPath.string() + " 2>/dev/null";
 
-  llvm::Expected<clang::tooling::CommonOptionsParser> expectedParser =
-      clang::tooling::CommonOptionsParser::create(argc, argv.data(), myToolCategory);
-
-  if (!expectedParser) {
-    llvm::errs() << expectedParser.takeError();
-    std::filesystem::remove(verifierPath);
-    return 0;
-  }
-
-  clang::tooling::CommonOptionsParser &optionsParser = expectedParser.get();
-
-  clang::tooling::ClangTool tool(optionsParser.getCompilations(),
-                                 optionsParser.getSourcePathList());
-
-  clang::IgnoringDiagConsumer diagConsumer;
-  tool.setDiagnosticConsumer(&diagConsumer);
-
-  int result = tool.run(
-      clang::tooling::newFrontendActionFactory<clang::SyntaxOnlyAction>().get());
-
+  int result = std::system(cmd.c_str());
   std::filesystem::remove(verifierPath);
   return result == 0 ? 1 : 0;
 }

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -1,6 +1,7 @@
 #include "include/Transformer.hpp"
 #include "ArgsFrontendActionFactory.hpp"
 #include "ClangToolUtils.hpp"
+#include "DebugLog.hpp"
 
 #include <clang/Basic/Diagnostic.h>
 #include <clang/Basic/DiagnosticIDs.h>
@@ -52,6 +53,7 @@ Transformer::Transformer(std::string configFile) : configuration() {
   configuration.wipeOldBenchmarks = defaultWipeOldBenchmarks;
   configuration.fileTimeoutSecs = defaultFileTimeoutSecs;
   parseConfig(configFile);
+  globalDebugLevel() = configuration.debugLevel;
 }
 
 // Flatten the filtered path into a single filename under benchmarkDir:
@@ -74,7 +76,7 @@ std::filesystem::path Transformer::flattenedOutputPath(std::filesystem::path pat
 }
 
 bool Transformer::transformFile(std::filesystem::path path) {
-  std::cout << "Transforming: " << path.string() << std::endl;
+  debugLog(1, "Transforming: " + path.string());
   if (!std::filesystem::exists(path))
     return false;
 
@@ -149,6 +151,7 @@ bool Transformer::transformFile(std::filesystem::path path) {
 // produced benchmark, 0 otherwise; the parent enforces a wall-clock timeout
 // and reaps the child, translating its fate into the success count.
 int Transformer::transformFileIsolated(std::filesystem::path path) {
+  _totalProcessed++;
   pid_t pid = fork();
   if (pid < 0) {
     std::cerr << "fork failed, transforming in-process: " << path.string() << std::endl;
@@ -375,10 +378,15 @@ void Transformer::parseConfig(std::string configFile) {
 
 int Transformer::run() {
   std::filesystem::path path(configuration.filterDir);
-  if (std::filesystem::exists(path)) {
-    int result = transformAll(path, 0);
-    std::cout << "Number of Compilable Benchmarks: " << result << std::endl;
-    return result;
+  if (!std::filesystem::exists(path)) {
+    std::cerr << "Filter directory not found: " << configuration.filterDir << std::endl;
+    return 0;
   }
-  return 0;
+  int result = transformAll(path, 0);
+  int discarded = _totalProcessed - result;
+  std::cout << "\n=== Transform summary ===\n"
+            << "  Files processed:        " << _totalProcessed << "\n"
+            << "  Benchmarks produced:    " << result << "\n"
+            << "  Discarded/failed:       " << discarded << std::endl;
+  return result;
 }

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -29,6 +29,10 @@
 #include <string>
 #include <system_error>
 #include <vector>
+#include <csignal>
+#include <ctime>
+#include <sys/wait.h>
+#include <unistd.h>
 
 const int defaultDebugLevel = 0;
 const bool defaultKeepCompilesOnly = true;
@@ -36,6 +40,8 @@ const std::string defaultFilterDir = "filteredFiles";
 const std::string defaultBenchmarkDir = "benchmarks";
 /// Not yet implemented in code - currently handled by scripts
 const bool defaultWipeOldBenchmarks = true;
+/// Per-file wall-clock budget for the isolated transform child, in seconds.
+const int defaultFileTimeoutSecs = 60;
 
 Transformer::Transformer(std::string configFile) : configuration() {
   // Apply defaults; parseConfig overrides any keys present in configFile
@@ -44,19 +50,16 @@ Transformer::Transformer(std::string configFile) : configuration() {
   configuration.filterDir = defaultFilterDir;
   configuration.benchmarkDir = defaultBenchmarkDir;
   configuration.wipeOldBenchmarks = defaultWipeOldBenchmarks;
+  configuration.fileTimeoutSecs = defaultFileTimeoutSecs;
   parseConfig(configFile);
 }
 
-bool Transformer::transformFile(std::filesystem::path path) {
-  std::cout << "Transforming: " << path.string() << std::endl;
-  if (!std::filesystem::exists(path))
-    return false;
-
-  // Flatten the filtered path into a single filename under benchmarkDir:
-  //   filtered-files/antirez/redis/src/endianconv.c
-  //   → transformed-files/antirez_redis_src_endianconv.c
-  // Strip the filterDir prefix (works for both relative and absolute paths),
-  // then join remaining components with underscores.
+// Flatten the filtered path into a single filename under benchmarkDir:
+//   filtered-files/antirez/redis/src/endianconv.c
+//   → transformed-files/antirez_redis_src_endianconv.c
+// Strip the filterDir prefix (works for both relative and absolute paths),
+// then join remaining components with underscores.
+std::filesystem::path Transformer::flattenedOutputPath(std::filesystem::path path) {
   std::filesystem::path relPath = std::filesystem::relative(path, configuration.filterDir);
   std::string flatName;
   for (const std::filesystem::path &component : relPath) {
@@ -67,8 +70,15 @@ bool Transformer::transformFile(std::filesystem::path path) {
       flatName += "_";
     flatName += part;
   }
-  std::filesystem::path srcPath =
-      std::filesystem::path(configuration.benchmarkDir) / flatName;
+  return std::filesystem::path(configuration.benchmarkDir) / flatName;
+}
+
+bool Transformer::transformFile(std::filesystem::path path) {
+  std::cout << "Transforming: " << path.string() << std::endl;
+  if (!std::filesystem::exists(path))
+    return false;
+
+  std::filesystem::path srcPath = flattenedOutputPath(path);
 
   // Tool setup: build the ClangTool from CLANG_RESOURCES and the source path
   static llvm::cl::OptionCategory myToolCategory("transformer");
@@ -133,6 +143,72 @@ bool Transformer::transformFile(std::filesystem::path path) {
   return 1;
 }
 
+// Runs transformFile in a forked child so a crash, OOM-kill, assertion, or
+// hang on a single pathological file cannot take down the whole batch. The
+// child does all the file I/O (rewritten .c, .yml, .i) and exits with 1 on a
+// produced benchmark, 0 otherwise; the parent enforces a wall-clock timeout
+// and reaps the child, translating its fate into the success count.
+int Transformer::transformFileIsolated(std::filesystem::path path) {
+  pid_t pid = fork();
+  if (pid < 0) {
+    std::cerr << "fork failed, transforming in-process: " << path.string() << std::endl;
+    return transformFile(path) ? 1 : 0;
+  }
+
+  if (pid == 0) {
+    // Child: do the work and report 1/0 through the exit status. _exit skips
+    // C++ stream flushing, so flush explicitly first (stdout may be fully
+    // buffered when redirected, e.g. under benchexec).
+    int produced = transformFile(path) ? 1 : 0;
+    std::cout.flush();
+    std::cerr.flush();
+    _exit(produced);
+  }
+
+  // Parent: poll for completion, killing the child if it overruns the budget.
+  time_t deadline = time(nullptr) + configuration.fileTimeoutSecs;
+  int status = 0;
+  while (true) {
+    pid_t done = waitpid(pid, &status, WNOHANG);
+    if (done == pid)
+      break;
+    if (done < 0) {
+      std::cerr << "waitpid failed for " << path.string() << std::endl;
+      return 0;
+    }
+    if (time(nullptr) >= deadline) {
+      std::cerr << "Timeout, killing transform of: " << path.string() << std::endl;
+      kill(pid, SIGKILL);
+      waitpid(pid, &status, 0);
+      cleanupPartialOutput(path);
+      return 0;
+    }
+    struct timespec nap = {0, 20 * 1000 * 1000}; // 20ms
+    nanosleep(&nap, nullptr);
+  }
+
+  if (WIFEXITED(status))
+    return WEXITSTATUS(status) == 1 ? 1 : 0;
+  // WIFSIGNALED: segfault, OOM-kill, etc. The child may have left a partial
+  // .c/.yml behind; harnessIsEmpty/keepCompilesOnly never ran, so clean up.
+  std::cerr << "Transform crashed (signal " << WTERMSIG(status) << "), skipping: "
+            << path.string() << std::endl;
+  cleanupPartialOutput(path);
+  return 0;
+}
+
+// Remove any .c/.yml/.i a crashed or timed-out child left half-written, so
+// downstream steps never see a partial benchmark.
+void Transformer::cleanupPartialOutput(std::filesystem::path path) {
+  std::filesystem::path srcPath = flattenedOutputPath(path);
+  std::error_code ec;
+  for (const char *ext : {".c", ".yml", ".i"}) {
+    std::filesystem::path p = srcPath;
+    p.replace_extension(ext);
+    std::filesystem::remove(p, ec);
+  }
+}
+
 int Transformer::transformAll(std::filesystem::path path, int count) {
   if (std::filesystem::exists(path)) {
     if (std::filesystem::is_directory(path)) {
@@ -144,7 +220,7 @@ int Transformer::transformAll(std::filesystem::path path, int count) {
       return count + successes;
     } else if (std::filesystem::is_regular_file(path)) {
       if (path.has_extension() && path.extension() == ".c") {
-        return count + transformFile(path);
+        return count + transformFileIsolated(path);
       }
     }
   }
@@ -287,6 +363,12 @@ void Transformer::parseConfig(std::string configFile) {
       configuration.keepCompilesOnly = (value == "true" || value == "True");
     } else if (key == "wipeOldBenchmarks") {
       configuration.wipeOldBenchmarks = (value == "true" || value == "True");
+    } else if (key == "fileTimeoutSecs") {
+      try {
+        configuration.fileTimeoutSecs = std::stoi(value);
+      } catch (...) {
+        configuration.fileTimeoutSecs = defaultFileTimeoutSecs;
+      }
     }
   }
 }

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -122,6 +122,14 @@ bool Transformer::transformFile(std::filesystem::path path) {
     return 0;
   }
   writeBenchmarkTask(srcPath);
+  if (!preprocess(srcPath)) {
+    std::cerr << "Preprocessing failed, discarding: " << srcPath.string() << std::endl;
+    std::filesystem::path ymlPath = srcPath;
+    ymlPath.replace_extension(".yml");
+    std::filesystem::remove(srcPath);
+    std::filesystem::remove(ymlPath);
+    return 0;
+  }
   return 1;
 }
 
@@ -276,6 +284,15 @@ void Transformer::writeBenchmarkTask(std::filesystem::path cPath) {
       << "options:\n"
       << "  language: C\n"
       << "  data_model: LP64\n";
+}
+
+bool Transformer::preprocess(std::filesystem::path cPath) {
+  std::filesystem::path iPath = cPath;
+  iPath.replace_extension(".i");
+
+  std::string cmd = "gcc -E -P -std=gnu11 " +
+                    cPath.string() + " -o " + iPath.string() + " 2>/dev/null";
+  return std::system(cmd.c_str()) == 0;
 }
 
 void Transformer::parseConfig(std::string configFile) {

--- a/src/transform/include/AddStdIncludesConsumer.hpp
+++ b/src/transform/include/AddStdIncludesConsumer.hpp
@@ -8,10 +8,32 @@
 #include <set>
 #include <string>
 
+/**
+ * @brief ASTConsumer that re-injects standard headers stripped includes left missing.
+ *
+ * Include stripping removes the project headers through which standard types
+ * like {@code size_t}, {@code bool}, {@code FILE}, or {@code uint32_t} were
+ * transitively available. This consumer walks the AST for used types, maps each
+ * to its standard header via {@code StdHeaders.hpp}, and inserts any needed
+ * {@code #include <...>} not already present (tracked in {@code existingIncludes}).
+ */
 class AddStdIncludesConsumer : public clang::ASTConsumer {
 public:
+  /**
+   * @brief Constructs the consumer with the shared pipeline state.
+   *
+   * @param existingIncludes System includes already present in the file (recorded
+   *        by {@code IncludeFinder}); used to avoid emitting duplicates.
+   * @param rewriter         Shared rewriter for modifying the source buffer.
+   */
   AddStdIncludesConsumer(std::shared_ptr<std::set<std::string>> existingIncludes,
                          clang::Rewriter &rewriter);
+
+  /**
+   * @brief Collects used standard types and inserts the headers they require.
+   *
+   * @param Context The AST context for the translation unit being transformed.
+   */
   void HandleTranslationUnit(clang::ASTContext &Context) override;
 
 private:

--- a/src/transform/include/Transformer.hpp
+++ b/src/transform/include/Transformer.hpp
@@ -180,4 +180,6 @@ public:
 private:
   /// Path settings and flags loaded from the config file.
   struct transformConfigs configuration;
+  /// Count of .c files attempted across the run, for the end-of-run summary.
+  int _totalProcessed = 0;
 };

--- a/src/transform/include/Transformer.hpp
+++ b/src/transform/include/Transformer.hpp
@@ -136,6 +136,17 @@ public:
    */
   void writeBenchmarkTask(std::filesystem::path cPath);
 
+  /**
+   * @brief Preprocesses a transformed .c file into a .i file.
+   *
+   * Runs {@code gcc -E -P -std=gnu11} on the source file, writing the
+   * preprocessed output alongside it with a {@code .i} extension.
+   *
+   * @param cPath Path to the transformed .c benchmark file.
+   * @return true if preprocessing succeeded, false otherwise.
+   */
+  bool preprocess(std::filesystem::path cPath);
+
 private:
   /// Path settings and flags loaded from the config file.
   struct transformConfigs configuration;

--- a/src/transform/include/Transformer.hpp
+++ b/src/transform/include/Transformer.hpp
@@ -30,6 +30,7 @@ struct transformConfigs {
   std::string filterDir;    ///< Input directory containing filtered C files to transform.
   std::string benchmarkDir; ///< Output directory for transformed benchmark files.
   bool wipeOldBenchmarks;   ///< Not yet implemented; reserved for future use.
+  int fileTimeoutSecs;      ///< Wall-clock budget per file for the isolated transform child.
 };
 
 /**
@@ -61,6 +62,35 @@ public:
    * @return false if the AST tool failed to run; otherwise true.
    */
   bool transformFile(std::filesystem::path path);
+
+  /**
+   * @brief Runs {@code transformFile} in a forked child for crash isolation.
+   *
+   * A segfault, OOM-kill, assertion, or hang on a single pathological file
+   * would otherwise take down the whole batch, since each file's ClangTool
+   * runs in-process. The child does the file I/O and reports success through
+   * its exit status; the parent enforces {@code fileTimeoutSecs} and cleans up
+   * any partial output left by a child that crashed or timed out.
+   *
+   * @param path Path to the filtered C source file to transform.
+   * @return 1 if a benchmark was produced, 0 otherwise.
+   */
+  int transformFileIsolated(std::filesystem::path path);
+
+  /**
+   * @brief Computes the flattened benchmarkDir output path for a filtered file.
+   *
+   * @param path Path to the filtered C source file.
+   * @return The {@code benchmarkDir/<flattened>.c} path the transform writes to.
+   */
+  std::filesystem::path flattenedOutputPath(std::filesystem::path path);
+
+  /**
+   * @brief Removes any .c/.yml/.i a crashed or timed-out child left behind.
+   *
+   * @param path Path to the filtered C source file whose output to clean up.
+   */
+  void cleanupPartialOutput(std::filesystem::path path);
 
   /**
    * @brief Recursively walks a directory tree, transforming every .c file found.

--- a/src/transform/main.cpp
+++ b/src/transform/main.cpp
@@ -1,8 +1,10 @@
 #include "include/Transformer.hpp"
+#include "ClangToolUtils.hpp"
 #include <iostream>
 
 /// Main function should be transfered to a driver for use via the full implementation
 int main(int argc, char **argv) {
+  checkClangVersion();
   if (argc == 2) {
     Transformer transformer(argv[1]);
     transformer.run();

--- a/tests/transform/TransformStageTest.cpp
+++ b/tests/transform/TransformStageTest.cpp
@@ -68,6 +68,7 @@ TEST_F(TransformStageTest, FlatFileProducesYml) {
 
   EXPECT_GE(count, 1);
   EXPECT_TRUE(fs::exists(benchmarkDir / "simple.c"));
+  EXPECT_TRUE(fs::exists(benchmarkDir / "simple.i"));
   EXPECT_TRUE(fs::exists(benchmarkDir / "simple.yml"));
 
   std::string yml = readFile(benchmarkDir / "simple.yml");


### PR DESCRIPTION
Continues the work done in #54 and does some additional refactoring and cleanup, e.g.:

- **Per-file crash isolation** (Transformer): each file now transforms in a forked child with a wall-clock timeout (fileTimeoutSecs, default 60s). Segfaults, OOM-kills, assertions, and hangs on one pathological file no longer abort the whole batch; partial output is cleaned up.
- **Preprocessing**: pipeline uses gcc -E -P (should be switched to clang really). Files that fail to preprocess are discarded.
- **Updated debug/logging**: Filter and transform now print end-of-run summaries.
- **Testing & Cleanup**: removed dead AddVerifiersVisitor, simplified checkCompilable, plus new golden + stage tests
