### PR TITLE
Feature/#56/natsteven/concurrency filtering

### DIFF
--- a/src/filter/CountingVisitor.cpp
+++ b/src/filter/CountingVisitor.cpp
@@ -5,7 +5,7 @@
 #include <clang/AST/ASTTypeTraits.h>
 #include <clang/AST/ParentMapContext.h>
 #include <clang/AST/RecursiveASTVisitor.h>
-#include <clang/AST/TypeBase.h>
+#include <clang/AST/Type.h>
 #include <clang/Basic/Specifiers.h>
 #include <clang/Basic/TypeTraits.h>
 

--- a/src/filter/CountingVisitor.cpp
+++ b/src/filter/CountingVisitor.cpp
@@ -1,8 +1,11 @@
 #include "include/CountingVisitor.hpp"
+#include "StdHeaders.hpp"
 
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/ASTTypeTraits.h>
 #include <clang/AST/ParentMapContext.h>
+#include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/AST/TypeBase.h>
 #include <clang/Basic/Specifiers.h>
 #include <clang/Basic/TypeTraits.h>
 
@@ -59,6 +62,23 @@ std::string CountingVisitor::getStmtParentFuncName(const clang::Stmt &S) {
   return "Program";
 }
 
+bool CountingVisitor::VisitCallExpr(clang::CallExpr *CE) {
+  if (!CE || !_mgr->isInMainFile(CE->getBeginLoc()))
+    return clang::RecursiveASTVisitor<CountingVisitor>::VisitCallExpr(CE);
+  // assumes all thread/concurrency calls will have types from concurrency related headers
+  for (const clang::Expr *arg : CE->arguments()) {
+    clang::QualType argType = arg->getType();
+    if (argType->isPointerType())
+      argType = argType->getPointeeType();
+    auto info = stdHeaderForType(argType.getUnqualifiedType().getAsString());
+    if (info && info->category == HeaderCategory::Concurrency) {
+      entryFor(getStmtParentFuncName(*CE)).Concurrency = 1;
+      break;
+    }
+  }
+  return clang::RecursiveASTVisitor<CountingVisitor>::VisitCallExpr(CE);
+}
+
 bool CountingVisitor::VisitDecl(clang::Decl *D) {
   if (!D)
     return false;
@@ -69,8 +89,15 @@ bool CountingVisitor::VisitVarDecl(clang::VarDecl *VD) {
   if (!VD)
     return false;
   if (_mgr->isInMainFile(VD->getLocation())) {
-    if (matchesType(VD->getType()))
+    clang::QualType varType = VD->getType();
+    if (matchesType(varType))
       entryFor(getDeclParentFuncName(*VD)).TypeVariables++;
+    // check for concurrency
+    if (varType->isPointerType())
+      varType = varType->getPointeeType();
+    auto info = stdHeaderForType(varType.getUnqualifiedType().getAsString());
+    if (info && info->category == HeaderCategory::Concurrency)
+      entryFor(getDeclParentFuncName(*VD)).Concurrency = 1;
   }
   return clang::RecursiveASTVisitor<CountingVisitor>::VisitVarDecl(VD);
 }

--- a/src/filter/FilterFunctionsConsumer.cpp
+++ b/src/filter/FilterFunctionsConsumer.cpp
@@ -34,7 +34,7 @@ void FilterFunctionsConsumer::FilterFunctions(clang::ASTContext &context) {
   for (const std::pair<const std::string, CountingVisitor::attributes> &func : *_ToFilter) {
     std::string key = func.first;
     CountingVisitor::attributes attr = func.second;
-    if (key == "Program" || key == "main") {
+    if (key == "Program") {
       continue;
     } else if (attr.Concurrency && _Config->at("Concurrency")) {
       _ToRemove->push_back(key);
@@ -102,8 +102,9 @@ void FilterFunctionsConsumer::FilterFunctions(clang::ASTContext &context) {
       // All threshold checks passed — now check whether every parameter has a
       // nondet equivalent. If any param type is unsupported (pointer, struct,
       // etc.), strip the body so HavocCallsVisitor can still use the return
-      // type from the remaining declaration.
-      if (declByName.contains(key)) {
+      // type from the remaining declaration. main is exempt here: its argc/argv
+      // params are handled specially by MainGenConsumer.
+      if (key != "main" && declByName.contains(key)) {
         for (auto parm : declByName.at(key)->parameters()) {
           if (!verifierSuffixForType(parm->getOriginalType())) {
             _ToRemove->push_back(key);

--- a/src/filter/FilterFunctionsConsumer.cpp
+++ b/src/filter/FilterFunctionsConsumer.cpp
@@ -36,6 +36,8 @@ void FilterFunctionsConsumer::FilterFunctions(clang::ASTContext &context) {
     CountingVisitor::attributes attr = func.second;
     if (key == "Program" || key == "main") {
       continue;
+    } else if (attr.Concurrency && _Config->at("Concurrency")) {
+      _ToRemove->push_back(key);
     } else if (attr.ForLoops > _Config->at("maxForLoops")) {
       _ToRemove->push_back(key);
     } else if (attr.WhileLoops > _Config->at("maxWhileLoops")) {

--- a/src/filter/RemoveVisitor.cpp
+++ b/src/filter/RemoveVisitor.cpp
@@ -14,7 +14,7 @@ bool RemoveVisitor::VisitFunctionDecl(clang::FunctionDecl *D) {
     if (D->getLocation().isMacroID())
       return clang::RecursiveASTVisitor<RemoveVisitor>::VisitFunctionDecl(D);
 
-    if (D->doesThisDeclarationHaveABody() && !D->isMain()) {
+    if (D->doesThisDeclarationHaveABody()) {
       for (const std::string &name : *_ToRemove) {
         if (name == D->getNameAsString()) {
           clang::SourceRange bodyRange = D->getBody()->getSourceRange();

--- a/src/filter/include/CountingVisitor.hpp
+++ b/src/filter/include/CountingVisitor.hpp
@@ -52,6 +52,7 @@ public:
     int TypeVariableReference = 0;
     int TypeVariables = 0;
     int WhileLoops = 0;
+    int Concurrency = 0;
   };
 
   /**
@@ -89,6 +90,12 @@ public:
    * @return   Function name, or {@code "Program"} if at file scope.
    */
   std::string getDeclParentFuncName(const clang::Decl &D);
+
+  /** @brief Checks calls for chacaracteristics (just concurrency for now)
+   * by looking at param types and marking parent/enclosing function as using
+   * concurrency
+   */
+  bool VisitCallExpr(clang::CallExpr *CE);
 
   /** @brief Catch-all for declaration nodes not handled by a more specific
    * visitor. */

--- a/src/filter/include/FilterFunctionsConsumer.hpp
+++ b/src/filter/include/FilterFunctionsConsumer.hpp
@@ -20,8 +20,6 @@
  * has already populated {@code toFilter} with per-function attribute counts. This
  * consumer just reads that map and applies the configured min/max thresholds, writing
  * any violating function names into {@code toRemove} for {@code RemoveConsumer} to act on.
- *
- * {@code "Program"} (file-scope counts) and {@code "main"} are always kept.
  */
 class FilterFunctionsConsumer : public clang::ASTConsumer {
 public:
@@ -45,7 +43,7 @@ public:
    * After all threshold checks, any function whose parameters include a type
    * with no {@code __VERIFIER_nondet_*} equivalent is also removed (body
    * stripped so the declaration survives for return-type resolution in the
-   * transform step). The {@code else if} chain prevents duplicates.
+   * transform step).
    */
   void FilterFunctions(clang::ASTContext &context);
 

--- a/src/filter/include/Filterer.hpp
+++ b/src/filter/include/Filterer.hpp
@@ -111,7 +111,8 @@ private:
    * maxFileLoC). Defaults are 0 for minimums and 99999 for maximums, meaning
    * no filtering unless explicitly configured.
    */
-  std::map<std::string, int> config = {{"debugLevel", 0},
+  std::map<std::string, int> config = {{"Concurrency", 0},
+                                       {"debugLevel", 0},
                                        {"maxCallFunc", 99999},
                                        {"maxFileLoC", 99999},
                                        {"maxForLoops", 99999},

--- a/src/filter/include/RemoveVisitor.hpp
+++ b/src/filter/include/RemoveVisitor.hpp
@@ -32,8 +32,8 @@ public:
   /**
    * @brief Replaces the body of each function in {@code _ToRemove} with {@code ;}.
    *
-   * Skips macro-expanded locations (not writable by the Rewriter), {@code main},
-   * and declarations with no body (already bare prototypes).
+   * Skips macro-expanded locations (not writable by the Rewriter) and
+   * declarations with no body (already bare prototypes).
    */
   bool VisitFunctionDecl(clang::FunctionDecl *D);
 

--- a/src/transform/HavocCallsVisitor.cpp
+++ b/src/transform/HavocCallsVisitor.cpp
@@ -38,11 +38,6 @@ bool HavocCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
     // Keep nondet calls already injected by the filter step
     if (callee->getIdentifier() && callee->getName().starts_with("__VERIFIER_"))
       return clang::RecursiveASTVisitor<HavocCallsVisitor>::VisitCallExpr(E);
-    // Keep calls into system headers (the C standard library and other
-    // platform headers). Everything else is project code and gets havocked:
-    // functions from this file, extern declarations written here, functions
-    // declared in repo-local headers, and implicit declarations (calls with
-    // no prototype in scope).
     if (!callee->isImplicit() && !mgr.isInMainFile(callee->getLocation()) &&
         mgr.isInSystemHeader(callee->getLocation()))
       return clang::RecursiveASTVisitor<HavocCallsVisitor>::VisitCallExpr(E);
@@ -59,15 +54,17 @@ bool HavocCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
     _Rewriter.ReplaceText(E->getSourceRange(), "__VERIFIER_nondet_" + *suffix + "()");
     _NeededSuffixes->emplace(*suffix);
   } else if (returnType->isAnyPointerType() && !returnType->isFunctionPointerType()) {
-    // Pointer returns get a havocked-but-valid block (SV-COMP
-    // __VERIFIER_nondet_memory semantics: dereferencing an arbitrary nondet
-    // pointer value is undefined, so the pointer itself must be real).
+    // Pointer returns get a havocked-but-valid block (SV-COMP __VERIFIER_nondet_memory).
     // Block size is a fixed guess for now; char pointers are
     // null-terminated so string ops stay in bounds. AddVerifiersConsumer
     // emits the helper definitions when it sees these markers.
     bool isCharPtr = returnType->getPointeeType()->isAnyCharacterType();
     std::string helper = isCharPtr ? "__havoc_cstring" : "__havoc_block";
-    _Rewriter.ReplaceText(E->getSourceRange(), helper + "(128)");
+    // The helpers return char* / void*; cast back to the call's actual
+    // return type so e.g. unsigned char* or a struct pointer doesn't end up
+    // assigned from an incompatible pointer type.
+    _Rewriter.ReplaceText(E->getSourceRange(),
+                           "(" + returnType.getAsString() + ")" + helper + "(128)");
     _NeededSuffixes->emplace(helper);
   }
   // Aggregate returns (structs, unions) have no expression-position nondet

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -337,8 +337,15 @@ bool Transformer::preprocess(std::filesystem::path cPath) {
   std::filesystem::path iPath = cPath;
   iPath.replace_extension(".i");
 
-  std::string cmd = "gcc -E -P -std=gnu11 " +
-                    cPath.string() + " -o " + iPath.string() + " 2>/dev/null";
+  std::optional<std::string> resourceDir = getResourceDir();
+  if (!resourceDir)
+    return false;
+
+  std::string cmd = "clang -E -P -std=gnu11 -resource-dir=" + *resourceDir;
+  std::optional<std::string> sysroot = getSysroot();
+  if (sysroot)
+    cmd += " -isysroot " + *sysroot;
+  cmd += " " + cPath.string() + " -o " + iPath.string() + " 2>/dev/null";
   return std::system(cmd.c_str()) == 0;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-add_executable(filter_tests filter/CountingVisitorTest.cpp)
+add_executable(filter_tests filter/CountingVisitorTest.cpp filter/FilterFunctionsConsumerTest.cpp)
 
 target_include_directories(filter_tests SYSTEM PRIVATE
   ${LLVM_INCLUDE_DIRS}
@@ -17,6 +17,7 @@ target_include_directories(filter_tests SYSTEM PRIVATE
 target_include_directories(filter_tests PRIVATE
   ${CMAKE_SOURCE_DIR}/src/filter/include
   ${CMAKE_SOURCE_DIR}/src/filter
+  ${CMAKE_SOURCE_DIR}/src/common/include
 )
 
 target_link_libraries(filter_tests PRIVATE

--- a/tests/filter/CountingVisitorTest.cpp
+++ b/tests/filter/CountingVisitorTest.cpp
@@ -176,3 +176,89 @@ TEST(CountingVisitor, ComparisonOperatorCounted) {
   ASSERT_TRUE(r.funcs->count("foo"));
   EXPECT_EQ(r.funcs->at("foo").TypeCompareOperation, 1);
 }
+
+// ---------------------------------------------------------------------------
+// Concurrency detection (pthread_* types)
+//
+// These tests deliberately typedef pthread_mutex_t/pthread_t locally instead
+// of #include <pthread.h>: detection is keyed purely on the type's spelled
+// name (via StdHeaders.hpp's kStdTypeHeaders), not on which header it came
+// from, so a hermetic typedef exercises the same code path as the real
+// system header without depending on it being present at test time.
+// ---------------------------------------------------------------------------
+
+namespace {
+const char *kPthreadStubs = R"(
+  typedef struct { int dummy; } pthread_mutex_t;
+  typedef unsigned long pthread_t;
+  int pthread_mutex_lock(pthread_mutex_t *m);
+  int pthread_mutex_unlock(pthread_mutex_t *m);
+)";
+}
+
+TEST(CountingVisitor, ConcurrencyFlaggedForLocalPthreadVariable) {
+  // A pthread_mutex_t declared and locked entirely inside the function should
+  // flag it via the VisitVarDecl path.
+  auto r = runCounter(std::string(kPthreadStubs) + R"(
+    void worker() {
+      pthread_mutex_t m;
+      pthread_mutex_lock(&m);
+      pthread_mutex_unlock(&m);
+    }
+  )");
+  ASSERT_TRUE(r.funcs->count("worker"));
+  EXPECT_TRUE(r.funcs->at("worker").Concurrency);
+}
+
+TEST(CountingVisitor, ConcurrencyFlaggedByCallArgumentAlone) {
+  // The pthread_mutex_t lives at file scope ("Program"), never as a VarDecl
+  // inside the function — only the call argument's type can catch this, so
+  // this isolates the VisitCallExpr path from the VisitVarDecl path.
+  auto r = runCounter(std::string(kPthreadStubs) + R"(
+    pthread_mutex_t global_lock;
+    void worker() {
+      pthread_mutex_lock(&global_lock);
+    }
+  )");
+  ASSERT_TRUE(r.funcs->count("worker"));
+  EXPECT_TRUE(r.funcs->at("worker").Concurrency);
+}
+
+TEST(CountingVisitor, ConcurrencyFlaggedForPointerTypedLocal) {
+  // A pointer-typed local (pthread_mutex_t *) with no call at all should
+  // still be flagged — VisitVarDecl strips the pointer before the lookup.
+  auto r = runCounter(std::string(kPthreadStubs) + R"(
+    void worker(pthread_mutex_t *m) {
+      pthread_mutex_t *alias = m;
+    }
+  )");
+  ASSERT_TRUE(r.funcs->count("worker"));
+  EXPECT_TRUE(r.funcs->at("worker").Concurrency);
+}
+
+TEST(CountingVisitor, ConcurrencyNotSetForCleanFunction) {
+  auto r = runCounter(std::string(kPthreadStubs) + R"(
+    int clean(int x) {
+      for (int i = 0; i < x; i++) {}
+      return x;
+    }
+  )");
+  ASSERT_TRUE(r.funcs->count("clean"));
+  EXPECT_FALSE(r.funcs->at("clean").Concurrency);
+}
+
+TEST(CountingVisitor, ConcurrencyIsolatedPerFunction) {
+  // Only the function that actually touches a pthread type should be
+  // flagged — a sibling function must not pick it up.
+  auto r = runCounter(std::string(kPthreadStubs) + R"(
+    void worker() {
+      pthread_mutex_t m;
+      pthread_mutex_lock(&m);
+    }
+    int clean(int x) { return x + 1; }
+  )");
+  ASSERT_TRUE(r.funcs->count("worker"));
+  ASSERT_TRUE(r.funcs->count("clean"));
+  EXPECT_TRUE(r.funcs->at("worker").Concurrency);
+  EXPECT_FALSE(r.funcs->at("clean").Concurrency);
+}

--- a/tests/filter/FilterFunctionsConsumerTest.cpp
+++ b/tests/filter/FilterFunctionsConsumerTest.cpp
@@ -1,0 +1,245 @@
+#include "CountingVisitor.hpp"
+#include "FilterFunctionsConsumer.hpp"
+#include "RemoveVisitor.hpp"
+
+#include <clang/Frontend/ASTUnit.h>
+#include <clang/Rewrite/Core/Rewriter.h>
+#include <clang/Tooling/Tooling.h>
+#include <gtest/gtest.h>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+//
+// These tests exercise the actual removal *decision* (FilterFunctionsConsumer)
+// and the body-stripping *action* (RemoveVisitor) that CountingVisitorTest.cpp
+// deliberately stops short of: that file only checks that attributes (like
+// Concurrency) are counted correctly, not what the pipeline does with them.
+
+namespace {
+
+// Mirrors Filterer's default threshold map: every max is permissive (99999)
+// and every min is permissive (0), so a test only needs to override the one
+// or two keys it cares about.
+std::map<std::string, int> permissiveConfig() {
+  return {{"Concurrency", 0},
+          {"maxCallFunc", 99999},
+          {"maxForLoops", 99999},
+          {"maxFunctions", 99999},
+          {"maxIfStmt", 99999},
+          {"maxParam", 99999},
+          {"maxTypeArithmeticOperation", 99999},
+          {"maxTypeCompareOperation", 99999},
+          {"maxTypeIfStmt", 99999},
+          {"maxTypeParameters", 99999},
+          {"maxTypePostfix", 99999},
+          {"maxTypePrefix", 99999},
+          {"maxTypeUnaryOperation", 99999},
+          {"maxTypeVariableReference", 99999},
+          {"maxTypeVariables", 99999},
+          {"maxWhileLoops", 99999},
+          {"minCallFunc", 0},
+          {"minForLoops", 0},
+          {"minFunctions", 0},
+          {"minIfStmt", 0},
+          {"minParam", 0},
+          {"minTypeArithmeticOperation", 0},
+          {"minTypeCompareOperation", 0},
+          {"minTypeIfStmt", 0},
+          {"minTypeParameters", 0},
+          {"minTypePostfix", 0},
+          {"minTypePrefix", 0},
+          {"minTypeUnaryOperation", 0},
+          {"minTypeVariableReference", 0},
+          {"minTypeVariables", 0},
+          {"minWhileLoops", 0}};
+}
+
+struct FilterResult {
+  std::unique_ptr<clang::ASTUnit> ast;
+  std::shared_ptr<std::unordered_map<std::string, CountingVisitor::attributes>> funcs =
+      std::make_shared<std::unordered_map<std::string, CountingVisitor::attributes>>();
+  std::shared_ptr<std::vector<std::string>> toRemove =
+      std::make_shared<std::vector<std::string>>();
+};
+
+// Parses `code`, runs CountingVisitor to populate real attribute counts, then
+// runs FilterFunctionsConsumer with `config` and returns what ended up in
+// _ToRemove.
+FilterResult runFilter(const std::string &code, std::map<std::string, int> config) {
+  FilterResult r;
+  r.ast = clang::tooling::buildASTFromCodeWithArgs(code, {"-xc"}, "test.c");
+  EXPECT_NE(r.ast, nullptr) << "AST failed to build for:\n" << code;
+  if (!r.ast)
+    return r;
+
+  CountingVisitor counter(&r.ast->getASTContext(), {}, r.funcs);
+  counter.TraverseTranslationUnitDecl(r.ast->getASTContext().getTranslationUnitDecl());
+
+  FilterFunctionsConsumer filterConsumer(r.funcs, r.toRemove, &config);
+  filterConsumer.FilterFunctions(r.ast->getASTContext());
+
+  return r;
+}
+
+bool contains(const std::vector<std::string> &v, const std::string &name) {
+  return std::find(v.begin(), v.end(), name) != v.end();
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// main + concurrency
+// ---------------------------------------------------------------------------
+
+TEST(FilterFunctionsConsumer, MainRemovedWhenConcurrencyFlagged) {
+  // pthread_create() called directly inside main (no helper function) — this
+  // is exactly the case that used to slip through filtering untouched.
+  auto config = permissiveConfig();
+  config["Concurrency"] = 1;
+  auto r = runFilter(R"(
+    typedef unsigned long pthread_t;
+    int pthread_create(pthread_t *t, void *attr, void *(*fn)(void *), void *arg);
+    void *worker(void *arg) { return arg; }
+    int main(void) {
+      pthread_t t;
+      pthread_create(&t, 0, worker, 0);
+      return 0;
+    }
+  )",
+                       config);
+  EXPECT_TRUE(contains(*r.toRemove, "main"));
+}
+
+TEST(FilterFunctionsConsumer, MainKeptWhenConcurrencyCheckDisabled) {
+  // Same body as above, but Concurrency=0 (the default) means the check is
+  // off entirely — main should survive untouched.
+  auto config = permissiveConfig();
+  auto r = runFilter(R"(
+    typedef unsigned long pthread_t;
+    int pthread_create(pthread_t *t, void *attr, void *(*fn)(void *), void *arg);
+    void *worker(void *arg) { return arg; }
+    int main(void) {
+      pthread_t t;
+      pthread_create(&t, 0, worker, 0);
+      return 0;
+    }
+  )",
+                       config);
+  EXPECT_FALSE(contains(*r.toRemove, "main"));
+}
+
+// ---------------------------------------------------------------------------
+// main + ordinary threshold checks
+// ---------------------------------------------------------------------------
+
+TEST(FilterFunctionsConsumer, MainRemovedByOrdinaryThresholdCheck) {
+  // main is no longer blanket-exempt from the general min/max ladder — a
+  // for-loop count over the configured max should remove it just like any
+  // other function.
+  auto config = permissiveConfig();
+  config["maxForLoops"] = 0;
+  auto r = runFilter(R"(
+    int main(void) {
+      for (int i = 0; i < 10; i++) {}
+      return 0;
+    }
+  )",
+                       config);
+  EXPECT_TRUE(contains(*r.toRemove, "main"));
+}
+
+TEST(FilterFunctionsConsumer, MainKeptWhenThresholdsSatisfied) {
+  auto config = permissiveConfig();
+  auto r = runFilter(R"(
+    int main(void) {
+      for (int i = 0; i < 10; i++) {}
+      return 0;
+    }
+  )",
+                       config);
+  EXPECT_FALSE(contains(*r.toRemove, "main"));
+}
+
+// ---------------------------------------------------------------------------
+// main + param-type check (the one exemption that remains)
+// ---------------------------------------------------------------------------
+
+TEST(FilterFunctionsConsumer, MainNotRemovedForUnsupportedArgvParam) {
+  // char** (argv) has no __VERIFIER_nondet_* equivalent — an ordinary
+  // function with this param type would be removed by the trailing
+  // param-type check, but main is exempt from that specific check since
+  // MainGenConsumer handles argc/argv itself.
+  auto config = permissiveConfig();
+  auto r = runFilter(R"(
+    int main(int argc, char **argv) {
+      return argc;
+    }
+  )",
+                       config);
+  EXPECT_FALSE(contains(*r.toRemove, "main"));
+}
+
+TEST(FilterFunctionsConsumer, OrdinaryFunctionRemovedForUnsupportedParam) {
+  // Sanity check that the param-type check still fires normally for
+  // non-main functions, so the main exemption above is verified against a
+  // real contrast rather than a check that never removes anything.
+  auto config = permissiveConfig();
+  auto r = runFilter(R"(
+    int main(void) { return 0; }
+    void helper(char **argv) {}
+  )",
+                       config);
+  EXPECT_TRUE(contains(*r.toRemove, "helper"));
+  EXPECT_FALSE(contains(*r.toRemove, "main"));
+}
+
+// ---------------------------------------------------------------------------
+// RemoveVisitor: does main's body actually get stripped once it's in
+// _ToRemove? (FilterFunctionsConsumer only decides; RemoveVisitor acts.)
+// ---------------------------------------------------------------------------
+
+TEST(RemoveVisitor, StripsMainBodyWhenListed) {
+  std::string code = R"(int main(void) { return 0; })";
+  auto ast = clang::tooling::buildASTFromCodeWithArgs(code, {"-xc"}, "test.c");
+  ASSERT_NE(ast, nullptr);
+
+  clang::SourceManager &mgr = ast->getSourceManager();
+  clang::Rewriter rewriter;
+  rewriter.setSourceMgr(mgr, ast->getLangOpts());
+
+  auto toRemove = std::make_shared<std::vector<std::string>>();
+  toRemove->push_back("main");
+
+  RemoveVisitor visitor(rewriter, toRemove);
+  visitor.TraverseDecl(ast->getASTContext().getTranslationUnitDecl());
+
+  std::string rewritten = std::string(
+      rewriter.getRewriteBufferFor(mgr.getMainFileID())->begin(),
+      rewriter.getRewriteBufferFor(mgr.getMainFileID())->end());
+  EXPECT_NE(rewritten.find("int main(void) ;"), std::string::npos) << rewritten;
+  EXPECT_EQ(rewritten.find("return 0"), std::string::npos) << rewritten;
+}
+
+TEST(RemoveVisitor, LeavesMainBodyWhenNotListed) {
+  std::string code = R"(int main(void) { return 0; })";
+  auto ast = clang::tooling::buildASTFromCodeWithArgs(code, {"-xc"}, "test.c");
+  ASSERT_NE(ast, nullptr);
+
+  clang::SourceManager &mgr = ast->getSourceManager();
+  clang::Rewriter rewriter;
+  rewriter.setSourceMgr(mgr, ast->getLangOpts());
+
+  auto toRemove = std::make_shared<std::vector<std::string>>(); // empty
+
+  RemoveVisitor visitor(rewriter, toRemove);
+  visitor.TraverseDecl(ast->getASTContext().getTranslationUnitDecl());
+
+  // No rewrite happened at all, so there's no rewrite buffer for this file.
+  EXPECT_EQ(rewriter.getRewriteBufferFor(mgr.getMainFileID()), nullptr);
+}

--- a/tests/transform/cases/havoc-by-return-type.expected.c
+++ b/tests/transform/cases/havoc-by-return-type.expected.c
@@ -22,8 +22,8 @@ float fval(void);
 int compute(int n) {
   int a = __VERIFIER_nondet_int();
   ;
-  char *s = __havoc_cstring(128);
-  int *b = __havoc_block(128);
+  char *s = (char *)__havoc_cstring(128);
+  int *b = (int *)__havoc_block(128);
   float f = __VERIFIER_nondet_float();
   return a + s[0] + b[0] + (int)f;
 }

--- a/tests/transform/cases/include-strip-local.expected.c
+++ b/tests/transform/cases/include-strip-local.expected.c
@@ -15,7 +15,7 @@ static char *__havoc_cstring(unsigned long size) {
 }
 
 int run(int n) {
-  char *s = __havoc_cstring(128);
+  char *s = (char *)__havoc_cstring(128);
   return __VERIFIER_nondet_int() + s[0];
 }
 


### PR DESCRIPTION
The filter step removes any usage of concurrency at the function scope. That is, any function that declares variables with types from, or calls a function defined in the concurrency category of `StdHeaders.cpp`

Also added new tests, and a fix for how the filter and transform stages handle main functions.