### PR TITLE
Feature/#61/natsteven/reconfig properties

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -210,6 +210,11 @@ main `int main(void) {\n  return 0;\n}`.
   handled; only the first two parameters (`argc`, `argv`) are synthesized
 - **Macro-expanded calls**: calls inside macro expansions have no rewritable source range
   and are skipped by the havoc pass
+- **K&R-style (old-style) declarations**: the pipeline assumes ANSI-prototyped function
+  declarations throughout (parameter typing, the filter's parameter-type gate, and
+  `HavocCallsVisitor`'s callee resolution all read from `FunctionDecl::parameters()`).
+  Old-style `int f(a, b) int a, b; { ... }` definitions are not explicitly detected or
+  special-cased, and their behavior through the pipeline is untested
 - **Typedef'd types**: a typedef to a supported builtin (e.g. `typedef int myint`) resolves
   correctly via `getAs<BuiltinType>()`, but a typedef to an unsupported type (e.g.
   `typedef struct foo bar`) is treated as unsupported

--- a/Design.md
+++ b/Design.md
@@ -47,7 +47,8 @@ Populates `databaseDir` with candidate C code from GitHub.
   and stops after `projectCount` repos.
 - Checks each repo URL is still reachable, then shallow-clones (`--depth=1`) into
   `downloadDir`.
-- Not part of the CMake build; invoked by `liveRun.sh` or run manually.
+- Not part of the CMake build; invoked directly (`python3 src/download/Downloader.py
+  properties.config`) or from the commented-out step in `run.sh`.
 
 ### 2. Filter (`src/filter/`, driver: `Filterer.cpp`)
 
@@ -108,8 +109,8 @@ Turns filtered files into self-contained, intraprocedural SV-Comp benchmarks.
 - **Post-processing** (`Transformer::transformFile`):
   - **Empty-harness discard**: if the generated `main` contains no function calls (every
     function was skipped), the output file is unconditionally deleted
-  - **Compile check**: the output is compiled with `clang -fsyntax-only` alongside
-    `verifier.c`; non-compiling benchmarks are deleted when `keepCompilesOnly` is set
+  - **Compile check**: the output is compiled with `clang -fsyntax-only`;
+    non-compiling benchmarks are deleted when `keepCompilesOnly` is set
   - **Preprocessing**: surviving benchmarks are preprocessed into a `.i` file with
     `gcc -E -P -std=gnu11` (the form SV-Comp consumes); on failure the `.c`/`.yml`/`.i`
     are removed
@@ -264,4 +265,3 @@ Verifier nondet naming and suffix→C-type mappings live in
 | `filter`    | `src/filter/`    | Filter stage only                                 |
 | `transform` | `src/transform/` | Transform stage only                              |
 | `full`      | `src/full/`      | Filter then Transform in one run                  |
-| `example`   | `src/example/`   | Prototype/scratchpad for new Clang patterns       |

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ArgV C Transformer
 
+[![Build and Test](https://github.com/unl-pal/argv-c-transformer/actions/workflows/ci.yaml/badge.svg)](https://github.com/unl-pal/argv-c-transformer/actions/workflows/ci.yaml)
+[![License](https://img.shields.io/github/license/unl-pal/argv-c-transformer)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/unl-pal/argv-c-transformer)](https://github.com/unl-pal/argv-c-transformer/releases)
+
 ArgV C Transformer takes C source files or directories and converts them into
 [SV-Comp](https://sv-comp.sosy-lab.org/) style verification benchmarks. It uses
 Clang/LLVM's C++ APIs to parse and rewrite C ASTs according to user-defined

--- a/properties.config
+++ b/properties.config
@@ -27,38 +27,36 @@ projectCount = 15
 minNumStars=0
 minRepoLoc=100
 
-[Function Requirements]
-# Filter-step thresholds, applied per function (main is exempt). A function
-# whose count falls outside [min, max] for any metric is removed and calls to
-# it are replaced with __VERIFIER_nondet_*. Unset mins default to 0 and unset
-# maxes to 99999, i.e. no filtering.
+[Complexity Requirements]
+# Filter-step thresholds, applied per function (main is not exempt from
+# these). A function whose count falls outside `min,max` for any metric is
+# removed and calls to it are replaced with __VERIFIER_nondet_*. Unset
+# metrics default to 0,99999, i.e. no filtering. Values are a comma-separated
+# `min,max` pair, not separate minX/maxX keys.
 #
-# Structural metrics (counted for every function):
-#   minForLoops  / maxForLoops
-#   minWhileLoops / maxWhileLoops
-#   minIfStmt    / maxIfStmt
-#   minCallFunc  / maxCallFunc        calls made by the function
-#   minParam     / maxParam           parameter count
-#   minFunctions / maxFunctions       function decls/refs inside the function
+#   ForLoops   — for-loop count
+#   WhileLoops — while-loop count
+#   IfStmt     — if-statement count
+#   CallFunc   — calls made by the function
+#   Param      — parameter count
+#   Functions  — function decls/refs inside the function
+ForLoops = 0,9999
+
+[Feature Requirements]
+# Filter-step gates, applied per function. Each feature is a presence flag
+# (does the function touch this at all), not a count, and is independent of
+# the Complexity Requirements above. Value is one of: ignore | require | forbid.
+# Unset features default to ignore.
 #
-# Type metrics (only constructs involving the types in `type` below):
-#   minTypeArithmeticOperation / maxTypeArithmeticOperation
-#   minTypeCompareOperation    / maxTypeCompareOperation
-#   minTypeIfStmt              / maxTypeIfStmt
-#   minTypeParameters          / maxTypeParameters
-#   minTypePostfix             / maxTypePostfix
-#   minTypePrefix              / maxTypePrefix
-#   minTypeUnaryOperation      / maxTypeUnaryOperation
-#   minTypeVariableReference   / maxTypeVariableReference
-#   minTypeVariables           / maxTypeVariables
-maxForLoops = 9999
-minTypeCompareOperation = 0
-minTypeIfStmt = 0
+#   Concurrency   — uses a concurrency-related type/call (e.g. pthread_*)
+#   FloatingPoint — uses float/double anywhere (param, local, or return type).
+#                   Currently tracked but not enforceable beyond ignore —
+#                   left here so it participates in the same config shape as
+#                   every other feature once filtering support lands.
+Concurrency = ignore
+FloatingPoint = ignore
 
 [File Requirements and Settings]
-# Types of interest for the Type* metrics above; space or comma separated.
-# Supported: Int Float Long Bool Char. Leave unset to count all types.
-# type=Int
 # File-level pre-filter on non-empty line count (filter step)
 minFileLoC=5
 maxFileLoC=9999

--- a/src/filter/CountingConsumer.cpp
+++ b/src/filter/CountingConsumer.cpp
@@ -3,11 +3,10 @@
 #include <llvm/Support/raw_ostream.h>
 
 CountingConsumer::CountingConsumer(
-    const std::vector<unsigned int> &types,
     std::shared_ptr<std::unordered_map<std::string, CountingVisitor::attributes>> toFilter)
-    : _Types(types), _ToFilter(toFilter) {}
+    : _ToFilter(toFilter) {}
 
 void CountingConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
-  CountingVisitor Visitor(&Context, _Types, _ToFilter);
+  CountingVisitor Visitor(&Context, _ToFilter);
   Visitor.TraverseTranslationUnitDecl(Context.getTranslationUnitDecl());
 }

--- a/src/filter/CountingVisitor.cpp
+++ b/src/filter/CountingVisitor.cpp
@@ -10,10 +10,9 @@
 #include <clang/Basic/TypeTraits.h>
 
 CountingVisitor::CountingVisitor(
-    clang::ASTContext *C, const std::vector<unsigned int> &T,
+    clang::ASTContext *C,
     std::shared_ptr<std::unordered_map<std::string, CountingVisitor::attributes>> allFunctions)
-    : _C(C), _mgr(&(C->getSourceManager())), _allFunctions(allFunctions), _T(T),
-      _allTypes(T.empty()) {
+    : _C(C), _mgr(&(C->getSourceManager())), _allFunctions(allFunctions) {
   _allFunctions->try_emplace("Program");
 }
 
@@ -22,16 +21,6 @@ CountingVisitor::attributes &CountingVisitor::entryFor(const std::string &name) 
   if (it == _allFunctions->end())
     it = _allFunctions->find("Program"); // always present (emplaced in ctor)
   return it->second;
-}
-
-bool CountingVisitor::matchesType(clang::QualType QT) const {
-  if (_allTypes)
-    return true;
-  for (unsigned int t : _T) {
-    if (QT->isSpecificBuiltinType(t))
-      return true;
-  }
-  return false;
 }
 
 std::string CountingVisitor::getDeclParentFuncName(const clang::Decl &D) {
@@ -72,7 +61,7 @@ bool CountingVisitor::VisitCallExpr(clang::CallExpr *CE) {
       argType = argType->getPointeeType();
     auto info = stdHeaderForType(argType.getUnqualifiedType().getAsString());
     if (info && info->category == HeaderCategory::Concurrency) {
-      entryFor(getStmtParentFuncName(*CE)).Concurrency = 1;
+      entryFor(getStmtParentFuncName(*CE)).Features.Concurrency = true;
       break;
     }
   }
@@ -90,14 +79,14 @@ bool CountingVisitor::VisitVarDecl(clang::VarDecl *VD) {
     return false;
   if (_mgr->isInMainFile(VD->getLocation())) {
     clang::QualType varType = VD->getType();
-    if (matchesType(varType))
-      entryFor(getDeclParentFuncName(*VD)).TypeVariables++;
-    // check for concurrency
     if (varType->isPointerType())
       varType = varType->getPointeeType();
+    if (varType->isFloatingType())
+      entryFor(getDeclParentFuncName(*VD)).Features.FloatingPoint = true;
+    // check for concurrency
     auto info = stdHeaderForType(varType.getUnqualifiedType().getAsString());
     if (info && info->category == HeaderCategory::Concurrency)
-      entryFor(getDeclParentFuncName(*VD)).Concurrency = 1;
+      entryFor(getDeclParentFuncName(*VD)).Features.Concurrency = true;
   }
   return clang::RecursiveASTVisitor<CountingVisitor>::VisitVarDecl(VD);
 }
@@ -108,18 +97,14 @@ bool CountingVisitor::VisitFunctionDecl(clang::FunctionDecl *FD) {
   if (_mgr->isInMainFile(FD->getLocation())) {
     if (!_allFunctions->count(FD->getNameAsString())) {
       _allFunctions->try_emplace(FD->getNameAsString());
-      _allFunctions->at("Program").Functions++;
+      _allFunctions->at("Program").Complexity.Functions++;
     }
+    attributes &entry = entryFor(FD->getNameAsString());
+    entry.Complexity.Param = FD->getNumParams();
+    if (FD->getReturnType()->isFloatingType())
+      entry.Features.FloatingPoint = true;
   }
   return clang::RecursiveASTVisitor<CountingVisitor>::VisitFunctionDecl(FD);
-}
-
-bool CountingVisitor::VisitDeclRefExpr(clang::DeclRefExpr *S) {
-  if (_mgr->isInMainFile(S->getLocation())) {
-    if (matchesType(S->getType()))
-      entryFor(getStmtParentFuncName(*S)).TypeVariableReference++;
-  }
-  return clang::RecursiveASTVisitor<CountingVisitor>::VisitDeclRefExpr(S);
 }
 
 bool CountingVisitor::VisitStmt(clang::Stmt *S) {
@@ -127,7 +112,7 @@ bool CountingVisitor::VisitStmt(clang::Stmt *S) {
     return false;
   if (_mgr->isInMainFile(S->getBeginLoc())) {
     if (S->getStmtClass() == clang::Stmt::CallExprClass)
-      entryFor(getStmtParentFuncName(*S)).CallFunc++;
+      entryFor(getStmtParentFuncName(*S)).Complexity.CallFunc++;
   }
   return clang::RecursiveASTVisitor<CountingVisitor>::VisitStmt(S);
 }
@@ -135,12 +120,8 @@ bool CountingVisitor::VisitStmt(clang::Stmt *S) {
 bool CountingVisitor::VisitIfStmt(clang::IfStmt *If) {
   if (!If)
     return false;
-  if (_mgr->isInMainFile(If->getIfLoc())) {
-    std::string currentFunc = getStmtParentFuncName(*If);
-    entryFor(currentFunc).IfStmt++;
-    if (matchesType(If->getCond()->getType()))
-      entryFor(currentFunc).TypeIfStmt++;
-  }
+  if (_mgr->isInMainFile(If->getIfLoc()))
+    entryFor(getStmtParentFuncName(*If)).Complexity.IfStmt++;
   return clang::RecursiveASTVisitor<CountingVisitor>::VisitIfStmt(If);
 }
 
@@ -148,7 +129,7 @@ bool CountingVisitor::VisitForStmt(clang::ForStmt *F) {
   if (!F)
     return false;
   if (_mgr->isInMainFile(F->getForLoc()))
-    entryFor(getStmtParentFuncName(*F)).ForLoops++;
+    entryFor(getStmtParentFuncName(*F)).Complexity.ForLoops++;
   return clang::RecursiveASTVisitor<CountingVisitor>::VisitForStmt(F);
 }
 
@@ -156,57 +137,6 @@ bool CountingVisitor::VisitWhileStmt(clang::WhileStmt *W) {
   if (!W)
     return false;
   if (_mgr->isInMainFile(W->getWhileLoc()))
-    entryFor(getStmtParentFuncName(*W)).WhileLoops++;
+    entryFor(getStmtParentFuncName(*W)).Complexity.WhileLoops++;
   return clang::RecursiveASTVisitor<CountingVisitor>::VisitWhileStmt(W);
-}
-
-bool CountingVisitor::VisitUnaryOperator(clang::UnaryOperator *O) {
-  if (!O)
-    return false;
-  if (_mgr->isInMainFile(O->getOperatorLoc()) && matchesType(O->getType())) {
-    std::string currentFunc = getStmtParentFuncName(*O);
-    if (O->isArithmeticOp())
-      entryFor(currentFunc).TypeArithmeticOperation++;
-    entryFor(currentFunc).TypeUnaryOperation++;
-    if (O->isPrefix())
-      entryFor(currentFunc).TypePrefix++;
-    if (O->isPostfix())
-      entryFor(currentFunc).TypePostfix++;
-  }
-  return clang::RecursiveASTVisitor<CountingVisitor>::VisitUnaryOperator(O);
-}
-
-bool CountingVisitor::VisitBinaryOperator(clang::BinaryOperator *O) {
-  if (!O)
-    return false;
-  if (_mgr->isInMainFile(O->getOperatorLoc()) && matchesType(O->getType())) {
-    std::string currentFunc = getStmtParentFuncName(*O);
-    if (O->isAdditiveOp())
-      entryFor(currentFunc).TypeArithmeticOperation++;
-    if (O->isComparisonOp()) {
-      entryFor(currentFunc).TypeCompareOperation++;
-      return clang::RecursiveASTVisitor<CountingVisitor>::VisitBinaryOperator(O);
-    }
-  }
-  return clang::RecursiveASTVisitor<CountingVisitor>::VisitBinaryOperator(O);
-}
-
-bool CountingVisitor::VisitConditionalOperator(clang::ConditionalOperator *O) {
-  if (!O)
-    return false;
-  if (_mgr->isInMainFile(O->getExprLoc()) && matchesType(O->getType()))
-    entryFor(getStmtParentFuncName(*O)).TypeCompareOperation++;
-  return clang::RecursiveASTVisitor<CountingVisitor>::VisitConditionalOperator(O);
-}
-
-bool CountingVisitor::VisitBinaryConditionalOperator(clang::BinaryConditionalOperator *O) {
-  if (!O)
-    return false;
-  return clang::RecursiveASTVisitor<CountingVisitor>::VisitBinaryConditionalOperator(O);
-}
-
-bool CountingVisitor::VisitImplicitParamDecl(clang::ImplicitParamDecl *D) {
-  if (matchesType(D->getType()))
-    entryFor(getDeclParentFuncName(*D)).TypeParameters++;
-  return clang::RecursiveASTVisitor<CountingVisitor>::VisitImplicitParamDecl(D);
 }

--- a/src/filter/FilterAction.cpp
+++ b/src/filter/FilterAction.cpp
@@ -15,9 +15,11 @@
 #include <unordered_map>
 #include <vector>
 
-FilterAction::FilterAction(std::map<std::string, int> *config,
-                           const std::vector<unsigned int> &types, llvm::raw_fd_ostream &output)
-    : _Config(config), _Types(types), _Rewriter(), _Output(output) {}
+FilterAction::FilterAction(std::map<std::string, std::pair<int, int>> *complexityConfig,
+                           std::map<std::string, FeatureGate> *featureConfig,
+                           llvm::raw_fd_ostream &output)
+    : _ComplexityConfig(complexityConfig), _FeatureConfig(featureConfig), _Rewriter(),
+      _Output(output) {}
 
 std::unique_ptr<clang::ASTConsumer>
 FilterAction::CreateASTConsumer(clang::CompilerInstance &compiler, llvm::StringRef /*filename*/) {
@@ -29,8 +31,9 @@ FilterAction::CreateASTConsumer(clang::CompilerInstance &compiler, llvm::StringR
   // unique_ptr can't be copied, so the vector must be moved into MultiplexConsumer.
   // Building a named local makes that std::move explicit and unambiguous.
   std::vector<std::unique_ptr<clang::ASTConsumer>> consumers;
-  consumers.emplace_back(std::make_unique<CountingConsumer>(_Types, toFilter));
-  consumers.emplace_back(std::make_unique<FilterFunctionsConsumer>(toFilter, toRemove, _Config));
+  consumers.emplace_back(std::make_unique<CountingConsumer>(toFilter));
+  consumers.emplace_back(std::make_unique<FilterFunctionsConsumer>(
+      toFilter, toRemove, _ComplexityConfig, _FeatureConfig));
   consumers.emplace_back(std::make_unique<RemoveConsumer>(_Rewriter, toRemove));
 
   return std::make_unique<clang::MultiplexConsumer>(std::move(consumers));

--- a/src/filter/FilterFunctionsConsumer.cpp
+++ b/src/filter/FilterFunctionsConsumer.cpp
@@ -6,12 +6,49 @@
 #include <clang/AST/DeclBase.h>
 #include <clang/Basic/SourceManager.h>
 #include <llvm/Support/Casting.h>
+#include <stdexcept>
 #include <unordered_map>
+
+namespace {
+
+// Looks up a named field on the complexity axis. Throws if `name` isn't one
+// of the known metrics — a config key typo should surface loudly, not
+// silently no-op.
+int complexityField(const CountingVisitor::ComplexityCounts &c, const std::string &name) {
+  if (name == "CallFunc")
+    return c.CallFunc;
+  if (name == "ForLoops")
+    return c.ForLoops;
+  if (name == "Functions")
+    return c.Functions;
+  if (name == "IfStmt")
+    return c.IfStmt;
+  if (name == "Param")
+    return c.Param;
+  if (name == "WhileLoops")
+    return c.WhileLoops;
+  throw std::invalid_argument("unknown complexity metric: " + name);
+}
+
+// Looks up a named flag on the feature axis. Throws if `name` isn't one of
+// the known features, for the same reason as complexityField above.
+bool featureField(const CountingVisitor::FeatureFlags &f, const std::string &name) {
+  if (name == "Concurrency")
+    return f.Concurrency;
+  if (name == "FloatingPoint")
+    return f.FloatingPoint;
+  throw std::invalid_argument("unknown feature: " + name);
+}
+
+} // namespace
 
 FilterFunctionsConsumer::FilterFunctionsConsumer(
     std::shared_ptr<std::unordered_map<std::string, CountingVisitor::attributes>> toFilter,
-    std::shared_ptr<std::vector<std::string>> toRemove, std::map<std::string, int> *config)
-    : _ToFilter(toFilter), _ToRemove(toRemove), _Config(config) {}
+    std::shared_ptr<std::vector<std::string>> toRemove,
+    std::map<std::string, std::pair<int, int>> *complexityConfig,
+    std::map<std::string, FeatureGate> *featureConfig)
+    : _ToFilter(toFilter), _ToRemove(toRemove), _ComplexityConfig(complexityConfig),
+      _FeatureConfig(featureConfig) {}
 
 void FilterFunctionsConsumer::HandleTranslationUnit(clang::ASTContext &context) {
   FilterFunctions(context);
@@ -33,83 +70,43 @@ void FilterFunctionsConsumer::FilterFunctions(clang::ASTContext &context) {
 
   for (const std::pair<const std::string, CountingVisitor::attributes> &func : *_ToFilter) {
     std::string key = func.first;
-    CountingVisitor::attributes attr = func.second;
-    if (key == "Program") {
+    const CountingVisitor::attributes &attr = func.second;
+    if (key == "Program")
       continue;
-    } else if (attr.Concurrency && _Config->at("Concurrency")) {
+
+    bool reject = false;
+    for (const auto &[name, range] : *_ComplexityConfig) {
+      int value = complexityField(attr.Complexity, name);
+      if (value < range.first || value > range.second) {
+        reject = true;
+        break;
+      }
+    }
+    if (!reject) {
+      for (const auto &[name, gate] : *_FeatureConfig) {
+        bool present = featureField(attr.Features, name);
+        if ((gate == FeatureGate::Require && !present) ||
+            (gate == FeatureGate::Forbid && present)) {
+          reject = true;
+          break;
+        }
+      }
+    }
+    if (reject) {
       _ToRemove->push_back(key);
-    } else if (attr.ForLoops > _Config->at("maxForLoops")) {
-      _ToRemove->push_back(key);
-    } else if (attr.WhileLoops > _Config->at("maxWhileLoops")) {
-      _ToRemove->push_back(key);
-    } else if (attr.CallFunc > _Config->at("maxCallFunc")) {
-      _ToRemove->push_back(key);
-    } else if (attr.Functions > _Config->at("maxFunctions")) {
-      _ToRemove->push_back(key);
-    } else if (attr.IfStmt > _Config->at("maxIfStmt")) {
-      _ToRemove->push_back(key);
-    } else if (attr.Param > _Config->at("maxParam")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeArithmeticOperation > _Config->at("maxTypeArithmeticOperation")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeCompareOperation > _Config->at("maxTypeCompareOperation")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeIfStmt > _Config->at("maxTypeIfStmt")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeParameters > _Config->at("maxTypeParameters")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypePostfix > _Config->at("maxTypePostfix")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypePrefix > _Config->at("maxTypePrefix")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeUnaryOperation > _Config->at("maxTypeUnaryOperation")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeVariableReference > _Config->at("maxTypeVariableReference")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeVariables > _Config->at("maxTypeVariables")) {
-      _ToRemove->push_back(key);
-    } else if (attr.CallFunc < _Config->at("minCallFunc")) {
-      _ToRemove->push_back(key);
-    } else if (attr.ForLoops < _Config->at("minForLoops")) {
-      _ToRemove->push_back(key);
-    } else if (attr.Functions < _Config->at("minFunctions")) {
-      _ToRemove->push_back(key);
-    } else if (attr.IfStmt < _Config->at("minIfStmt")) {
-      _ToRemove->push_back(key);
-    } else if (attr.Param < _Config->at("minParam")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeArithmeticOperation < _Config->at("minTypeArithmeticOperation")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeCompareOperation < _Config->at("minTypeCompareOperation")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeIfStmt < _Config->at("minTypeIfStmt")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeParameters < _Config->at("minTypeParameters")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypePostfix < _Config->at("minTypePostfix")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypePrefix < _Config->at("minTypePrefix")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeUnaryOperation < _Config->at("minTypeUnaryOperation")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeVariableReference < _Config->at("minTypeVariableReference")) {
-      _ToRemove->push_back(key);
-    } else if (attr.TypeVariables < _Config->at("minTypeVariables")) {
-      _ToRemove->push_back(key);
-    } else if (attr.WhileLoops < _Config->at("minWhileLoops")) {
-      _ToRemove->push_back(key);
-    } else {
-      // All threshold checks passed — now check whether every parameter has a
-      // nondet equivalent. If any param type is unsupported (pointer, struct,
-      // etc.), strip the body so HavocCallsVisitor can still use the return
-      // type from the remaining declaration. main is exempt here: its argc/argv
-      // params are handled specially by MainGenConsumer.
-      if (key != "main" && declByName.contains(key)) {
-        for (auto parm : declByName.at(key)->parameters()) {
-          if (!verifierSuffixForType(parm->getOriginalType())) {
-            _ToRemove->push_back(key);
-            break;
-          }
+      continue;
+    }
+
+    // All threshold checks passed — now check whether every parameter has a
+    // nondet equivalent. If any param type is unsupported (pointer, struct,
+    // etc.), strip the body so HavocCallsVisitor can still use the return
+    // type from the remaining declaration. main is exempt here: its argc/argv
+    // params are handled specially by MainGenConsumer.
+    if (key != "main" && declByName.contains(key)) {
+      for (auto parm : declByName.at(key)->parameters()) {
+        if (!verifierSuffixForType(parm->getOriginalType())) {
+          _ToRemove->push_back(key);
+          break;
         }
       }
     }

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -169,9 +169,18 @@ int Filterer::getAllCFiles(std::filesystem::path pathObject,
       return 0;
     }
   } else if (std::filesystem::is_directory(pathObject)) {
-    for (const std::filesystem::directory_entry &entry :
-         std::filesystem::directory_iterator(pathObject)) {
-      numFiles += getAllCFiles(entry.path(), filesToFilter);
+    // pathObject may come from an untrusted cloned repo, so a broken symlink
+    // or a permissions error partway through the scan is expected, not
+    // exceptional. Don't let it abort the whole batch — log and move on with
+    // whatever files were already queued.
+    try {
+      for (const std::filesystem::directory_entry &entry :
+           std::filesystem::directory_iterator(pathObject)) {
+        numFiles += getAllCFiles(entry.path(), filesToFilter);
+      }
+    } catch (const std::filesystem::filesystem_error &e) {
+      debugLog(1, "[filter] skipping unreadable directory " + pathObject.string() +
+                      ": " + e.what());
     }
     return numFiles;
   } else {

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -30,13 +30,53 @@ Filterer::Filterer(std::string configFile) {
   parseConfigFile(configFile);
 };
 
+namespace {
+
+std::string trim(const std::string &s) {
+  size_t start = s.find_first_not_of(" \t");
+  size_t end = s.find_last_not_of(" \t");
+  if (start == std::string::npos)
+    return "";
+  return s.substr(start, end - start + 1);
+}
+
+} // namespace
+
 void Filterer::parseConfigFile(std::string configFile) {
   if (!std::filesystem::exists(configFile)) {
     std::cerr << "Config file not found: " << configFile << " — using defaults" << std::endl;
     return;
   }
   for (auto [key, value] : parseIniFile(configFile)) {
-    if (config.count(key)) {
+    if (complexityConfig.count(key)) {
+      size_t comma = value.find(',');
+      if (comma == std::string::npos) {
+        std::cerr << "Warning: complexity key '" << key
+                  << "' expects 'min,max' — ignoring value '" << value << "'" << std::endl;
+        continue;
+      }
+      try {
+        int min = std::stoi(trim(value.substr(0, comma)));
+        int max = std::stoi(trim(value.substr(comma + 1)));
+        complexityConfig.at(key) = {min, max};
+      } catch (...) {
+        std::cerr << "Warning: could not parse complexity range for '" << key << "': '" << value
+                  << "'" << std::endl;
+      }
+    } else if (featureConfig.count(key)) {
+      std::string v = trim(value);
+      std::transform(v.begin(), v.end(), v.begin(), ::tolower);
+      if (v == "require") {
+        featureConfig.at(key) = FeatureGate::Require;
+      } else if (v == "forbid") {
+        featureConfig.at(key) = FeatureGate::Forbid;
+      } else if (v == "ignore" || v.empty()) {
+        featureConfig.at(key) = FeatureGate::Ignore;
+      } else {
+        std::cerr << "Warning: unrecognised gate '" << value << "' for feature '" << key
+                  << "' — ignoring" << std::endl;
+      }
+    } else if (config.count(key)) {
       try {
         int i = std::stoi(value);
         config.at(key) = i;
@@ -46,30 +86,6 @@ void Filterer::parseConfigFile(std::string configFile) {
         config.at(key) = 0;
       } else if (value == "true" || value == "True") {
         config.at(key) = 1;
-      }
-    } else if (key == "type" || key == "Type") {
-      std::regex typePattern("([\\w]+)");
-      std::smatch typeMatches;
-      while (std::regex_search(value, typeMatches, typePattern)) {
-        if (typeMatches[0] == "int" || typeMatches[0] == "Int") {
-          typesRequested.push_back(clang::BuiltinType::Int);
-          typeNames.push_back(typeMatches[0]);
-        } else if (typeMatches[0] == "float" || typeMatches[0] == "Float") {
-          typesRequested.push_back(clang::BuiltinType::Float);
-          typeNames.push_back(typeMatches[0]);
-        } else if (typeMatches[0] == "long" || typeMatches[0] == "Long") {
-          typesRequested.push_back(clang::BuiltinType::Long);
-          typeNames.push_back(typeMatches[0]);
-        } else if (typeMatches[0] == "bool" || typeMatches[0] == "Bool") {
-          typesRequested.push_back(clang::BuiltinType::Bool);
-          typeNames.push_back(typeMatches[0]);
-        } else if (typeMatches[0] == "char" || typeMatches[0] == "Char") {
-          typesRequested.push_back(clang::BuiltinType::UChar);
-          typeNames.push_back(typeMatches[0]);
-        } else {
-          std::cerr << "Warning: unrecognised type '" << typeMatches[0] << "' ignored" << std::endl;
-        }
-        value = typeMatches.suffix().str();
       }
     } else if (key == "databaseDir") {
       configuration.databaseDir = value;
@@ -98,8 +114,13 @@ void Filterer::parseConfigFile(std::string configFile) {
     std::string dump = "[filter] loaded config: " + configFile;
     for (const auto &[k, v] : config)
       dump += "\n  " + k + " = " + std::to_string(v);
-    for (const std::string &t : typeNames)
-      dump += "\n  type: " + t;
+    for (const auto &[k, range] : complexityConfig)
+      dump += "\n  " + k + " = " + std::to_string(range.first) + "," + std::to_string(range.second);
+    for (const auto &[k, gate] : featureConfig)
+      dump += "\n  " + k + " = " +
+              (gate == FeatureGate::Require   ? "require"
+               : gate == FeatureGate::Forbid ? "forbid"
+                                              : "ignore");
     debugLog(1, dump);
   }
 }
@@ -254,7 +275,7 @@ int Filterer::run() {
                                      optionsParser.getSourcePathList());
       tool.setDiagnosticConsumer(&diagConsumer);
 
-      FrontendFactoryWithArgs factory(&config, typesRequested, output);
+      FrontendFactoryWithArgs factory(&complexityConfig, &featureConfig, output);
 
       int result = tool.run(&factory);
       debugLog(2, "[filter] tool result for " + fileName + ": " + std::to_string(result));

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -169,9 +169,7 @@ int Filterer::getAllCFiles(std::filesystem::path pathObject,
       return 0;
     }
   } else if (std::filesystem::is_directory(pathObject)) {
-    // pathObject may come from an untrusted cloned repo, so a broken symlink
-    // or a permissions error partway through the scan is expected, not
-    // exceptional. Don't let it abort the whole batch — log and move on with
+    // Don't let filepath issues break loop, log and move on with
     // whatever files were already queued.
     try {
       for (const std::filesystem::directory_entry &entry :

--- a/src/filter/FrontendFactoryWithArgs.cpp
+++ b/src/filter/FrontendFactoryWithArgs.cpp
@@ -4,11 +4,11 @@
 #include <clang/Frontend/FrontendAction.h>
 #include <memory>
 
-FrontendFactoryWithArgs::FrontendFactoryWithArgs(std::map<std::string, int> *config,
-                                                 const std::vector<unsigned int> &types,
-                                                 llvm::raw_fd_ostream &output)
-    : _Config(config), _Types(types), _Output(output) {}
+FrontendFactoryWithArgs::FrontendFactoryWithArgs(
+    std::map<std::string, std::pair<int, int>> *complexityConfig,
+    std::map<std::string, FeatureGate> *featureConfig, llvm::raw_fd_ostream &output)
+    : _ComplexityConfig(complexityConfig), _FeatureConfig(featureConfig), _Output(output) {}
 
 std::unique_ptr<clang::FrontendAction> FrontendFactoryWithArgs::create() {
-  return std::make_unique<FilterAction>(_Config, _Types, _Output);
+  return std::make_unique<FilterAction>(_ComplexityConfig, _FeatureConfig, _Output);
 }

--- a/src/filter/include/CountingConsumer.hpp
+++ b/src/filter/include/CountingConsumer.hpp
@@ -7,7 +7,6 @@
 #include <clang/AST/Type.h>
 #include <memory>
 #include <unordered_map>
-#include <vector>
 
 /**
  * @brief ASTConsumer that drives the counting pass over the AST.
@@ -22,11 +21,9 @@ public:
   /**
    * @brief Constructs the consumer with the shared pipeline state.
    *
-   * @param types     Clang BuiltinType values for the requested verifier types.
    * @param toFilter  Output map; visitor writes function name → attribute counts.
    */
-  CountingConsumer(
-      const std::vector<unsigned int> &types,
+  explicit CountingConsumer(
       std::shared_ptr<std::unordered_map<std::string, CountingVisitor::attributes>> toFilter);
 
   /**
@@ -40,6 +37,5 @@ public:
   void HandleTranslationUnit(clang::ASTContext &context) override;
 
 private:
-  const std::vector<unsigned int> &_Types;
   std::shared_ptr<std::unordered_map<std::string, CountingVisitor::attributes>> _ToFilter;
 };

--- a/src/filter/include/CountingVisitor.hpp
+++ b/src/filter/include/CountingVisitor.hpp
@@ -13,6 +13,12 @@
 #include <vector>
 
 /**
+ * @brief Three-state gate for a feature flag: whether the config requires a
+ * function to have the feature present, forbids it, or doesn't care.
+ */
+enum class FeatureGate { Ignore, Require, Forbid };
+
+/**
  * @brief Recursively walks the AST and counts per-function properties.
  *
  * Uses CRTP ({@code RecursiveASTVisitor<CountingVisitor>}) so the base class
@@ -28,43 +34,36 @@
  */
 class CountingVisitor : public clang::RecursiveASTVisitor<CountingVisitor> {
 public:
-  /**
-   * @brief Per-function AST property counts.
-   *
-   * Fields prefixed {@code Type*} are gated on the requested builtin types
-   * (e.g. only count {@code TypeVariables} if the variable's type matches one
-   * of the configured types). Un-prefixed fields (e.g. {@code ForLoops}) count
-   * all occurrences regardless of type.
-   */
-  struct attributes {
+  /** @brief Per-function structural complexity counts — the "how much" axis. */
+  struct ComplexityCounts {
     int CallFunc = 0;
     int ForLoops = 0;
     int Functions = 0;
     int IfStmt = 0;
     int Param = 0;
-    int TypeArithmeticOperation = 0;
-    int TypeCompareOperation = 0;
-    int TypeIfStmt = 0;
-    int TypeParameters = 0;
-    int TypePostfix = 0;
-    int TypePrefix = 0;
-    int TypeUnaryOperation = 0;
-    int TypeVariableReference = 0;
-    int TypeVariables = 0;
     int WhileLoops = 0;
-    int Concurrency = 0;
+  };
+
+  /** @brief Per-function feature presence flags — the "what kind" axis. */
+  struct FeatureFlags {
+    bool Concurrency = false;
+    bool FloatingPoint = false;
+  };
+
+  /** @brief Per-function AST property counts, split across the two axes. */
+  struct attributes {
+    ComplexityCounts Complexity;
+    FeatureFlags Features;
   };
 
   /**
    * @brief Constructs the visitor and seeds the map with the "Program" entry.
    *
    * @param C             AST context, used for parent-map lookups.
-   * @param T             Clang BuiltinType values to count; empty means count
-   * all.
    * @param allFunctions  Output map shared with downstream consumers.
    */
   CountingVisitor(
-      clang::ASTContext *C, const std::vector<unsigned int> &T,
+      clang::ASTContext *C,
       std::shared_ptr<std::unordered_map<std::string, CountingVisitor::attributes>> allFunctions);
 
   /**
@@ -101,28 +100,19 @@ public:
    * visitor. */
   bool VisitDecl(clang::Decl *D);
 
-  /** @brief Counts type-matched variable declarations per function. */
+  /** @brief Counts variable declarations per function; flags floating-point
+   * and concurrency types. */
   bool VisitVarDecl(clang::VarDecl *VD);
 
-  /** @brief Registers each function in {@code _allFunctions} and increments the
-   * file-level function count. */
+  /** @brief Registers each function in {@code _allFunctions}, increments the
+   * file-level function count, and flags a floating-point return type. */
   bool VisitFunctionDecl(clang::FunctionDecl *FD);
-
-  /**
-   * @brief Counts type-matched variable references per function.
-   *
-   * {@code DeclRefExpr} is the AST node for any use of a named variable —
-   * it is an expression, not a declaration, so it appears under {@code Stmt}
-   * in the hierarchy.
-   */
-  bool VisitDeclRefExpr(clang::DeclRefExpr *D);
 
   /** @brief Catch-all for statement nodes; counts function calls ({@code
    * CallFunc}). */
   bool VisitStmt(clang::Stmt *S);
 
-  /** @brief Counts all if-statements and type-matched if-statement conditions.
-   */
+  /** @brief Counts all if-statements per function. */
   bool VisitIfStmt(clang::IfStmt *If);
 
   /** @brief Counts for-loop occurrences per function. */
@@ -130,44 +120,6 @@ public:
 
   /** @brief Counts while-loop occurrences per function. */
   bool VisitWhileStmt(clang::WhileStmt *W);
-
-  /**
-   * @brief Counts type-matched unary operations, distinguishing arithmetic,
-   * prefix, and postfix.
-   *
-   * Note: {@code VisitStmt} does not double-count these — the {@code
-   * UnaryOperatorClass} branch was removed from {@code VisitStmt} to avoid
-   * that.
-   */
-  bool VisitUnaryOperator(clang::UnaryOperator *O);
-
-  /** @brief Counts type-matched additive and comparison binary operations per
-   * function. */
-  bool VisitBinaryOperator(clang::BinaryOperator *O);
-
-  /** @brief Counts type-matched ternary ({@code x ? y : z}) operations per
-   * function. */
-  bool VisitConditionalOperator(clang::ConditionalOperator *O);
-
-  /**
-   * @brief Stub for GNU ({@code x ?: y}) — not currently counted.
-   *
-   * The standard ternary is handled by {@code VisitConditionalOperator};
-   * this form rarely appears in the filtered source files.
-   */
-  bool VisitBinaryConditionalOperator(clang::BinaryConditionalOperator *O);
-
-  /** @brief Counts type-matched implicit parameters (e.g. {@code self} in ObjC
-   * methods). */
-  bool VisitImplicitParamDecl(clang::ImplicitParamDecl *D);
-
-  /**
-   * @brief Returns true if {@code QT} should be counted given the type filter.
-   *
-   * When {@code _T} is empty (count-all mode), always returns true without
-   * iterating. Otherwise checks each requested builtin type.
-   */
-  bool matchesType(clang::QualType QT) const;
 
 private:
   /**
@@ -190,6 +142,4 @@ private:
   clang::ASTContext *_C;
   clang::SourceManager *_mgr;
   std::shared_ptr<std::unordered_map<std::string, attributes>> _allFunctions;
-  const std::vector<unsigned int> &_T;
-  bool _allTypes; ///< True when _T is empty — count all types
 };

--- a/src/filter/include/FilterAction.hpp
+++ b/src/filter/include/FilterAction.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CountingVisitor.hpp"
+
 #include <clang/AST/ASTConsumer.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendAction.h>
@@ -9,7 +11,7 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
+#include <utility>
 
 /**
  * @brief ASTFrontendAction that runs the full filter consumer chain.
@@ -23,12 +25,13 @@ public:
   /**
    * @brief Constructs the action with the shared pipeline state.
    *
-   * @param config  Threshold map owned by {@code Filterer}.
-   * @param types   Clang BuiltinType values for the requested verifier types.
-   * @param output  Destination file stream for the filtered output.
+   * @param complexityConfig  Per-metric [min, max] ranges owned by {@code Filterer}.
+   * @param featureConfig     Per-feature require/forbid/ignore gates owned by
+   *                          {@code Filterer}.
+   * @param output            Destination file stream for the filtered output.
    */
-  FilterAction(std::map<std::string, int> *config, const std::vector<unsigned int> &types,
-               llvm::raw_fd_ostream &output);
+  FilterAction(std::map<std::string, std::pair<int, int>> *complexityConfig,
+               std::map<std::string, FeatureGate> *featureConfig, llvm::raw_fd_ostream &output);
 
   /**
    * @brief Builds a {@code MultiplexConsumer} containing all three filter passes.
@@ -66,8 +69,8 @@ public:
   void EndSourceFileAction() override;
 
 private:
-  std::map<std::string, int> *_Config;
-  const std::vector<unsigned int> &_Types;
+  std::map<std::string, std::pair<int, int>> *_ComplexityConfig;
+  std::map<std::string, FeatureGate> *_FeatureConfig;
   clang::Rewriter _Rewriter;
   llvm::raw_fd_ostream &_Output;
 };

--- a/src/filter/include/FilterFunctionsConsumer.hpp
+++ b/src/filter/include/FilterFunctionsConsumer.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 /**
@@ -18,37 +19,48 @@
  *
  * Does not use a visitor — by the time this consumer runs, {@code CountingConsumer}
  * has already populated {@code toFilter} with per-function attribute counts. This
- * consumer just reads that map and applies the configured min/max thresholds, writing
- * any violating function names into {@code toRemove} for {@code RemoveConsumer} to act on.
+ * consumer just reads that map and applies the configured complexity ranges and
+ * feature gates, writing any violating function names into {@code toRemove} for
+ * {@code RemoveConsumer} to act on.
  */
 class FilterFunctionsConsumer : public clang::ASTConsumer {
 public:
   /**
    * @brief Constructs the consumer with the shared pipeline state.
    *
-   * @param toFilter  Map of function name → attribute counts, written by {@code CountingConsumer}.
-   * @param toRemove  Output vector; names of functions that fail thresholds are appended.
-   * @param config    Threshold map (min/max per attribute) owned by {@code Filterer}.
+   * @param toFilter          Map of function name → attribute counts, written by
+   *                          {@code CountingConsumer}.
+   * @param toRemove          Output vector; names of functions that fail thresholds
+   *                          are appended.
+   * @param complexityConfig  Per-metric [min, max] ranges, owned by {@code Filterer}.
+   * @param featureConfig     Per-feature require/forbid/ignore gates, owned by
+   *                          {@code Filterer}.
    */
   FilterFunctionsConsumer(
       std::shared_ptr<std::unordered_map<std::string, CountingVisitor::attributes>> toFilter,
-      std::shared_ptr<std::vector<std::string>> toRemove, std::map<std::string, int> *config);
+      std::shared_ptr<std::vector<std::string>> toRemove,
+      std::map<std::string, std::pair<int, int>> *complexityConfig,
+      std::map<std::string, FeatureGate> *featureConfig);
 
   void HandleTranslationUnit(clang::ASTContext &context) override;
 
   /**
-   * @brief Applies min/max thresholds and param-type checks to every function.
+   * @brief Applies complexity ranges, feature gates, and param-type checks to
+   * every function.
    *
-   * A function is added to {@code _ToRemove} on the first violation found.
-   * After all threshold checks, any function whose parameters include a type
-   * with no {@code __VERIFIER_nondet_*} equivalent is also removed (body
-   * stripped so the declaration survives for return-type resolution in the
-   * transform step).
+   * A function is added to {@code _ToRemove} on the first violation found:
+   * first every complexity metric is checked against its configured [min, max]
+   * range, then (if still in the running) every feature flag is checked
+   * against its configured gate. After that, any function whose parameters
+   * include a type with no {@code __VERIFIER_nondet_*} equivalent is also
+   * removed (body stripped so the declaration survives for return-type
+   * resolution in the transform step).
    */
   void FilterFunctions(clang::ASTContext &context);
 
 private:
   std::shared_ptr<std::unordered_map<std::string, CountingVisitor::attributes>> _ToFilter;
   std::shared_ptr<std::vector<std::string>> _ToRemove;
-  std::map<std::string, int> *_Config;
+  std::map<std::string, std::pair<int, int>> *_ComplexityConfig;
+  std::map<std::string, FeatureGate> *_FeatureConfig;
 };

--- a/src/filter/include/Filterer.hpp
+++ b/src/filter/include/Filterer.hpp
@@ -1,15 +1,19 @@
 #pragma once
 
+#include "CountingVisitor.hpp"
+
 #include <filesystem>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 /**
  * @brief Runtime configuration loaded from the INI-style config file.
  *
- * Holds the path settings and flags that live outside the numeric threshold
- * map — i.e. things that are not per-function min/max counts.
+ * Holds the path settings and flags that live outside the per-function
+ * config maps — i.e. things that are not per-function complexity ranges or
+ * feature gates.
  */
 struct filterConfigs {
   std::string databaseDir; ///< Directory containing the source repos to filter
@@ -35,11 +39,15 @@ public:
   Filterer(std::string configFile);
 
   /**
-   * @brief Parses the config file, populating the threshold map and type lists.
+   * @brief Parses the config file, populating the two per-function config
+   * maps and the file-level settings.
    *
-   * Numeric thresholds go into {@code config}. The special {@code type} key
-   * populates {@code typesRequested} and {@code typeNames}. Path settings go
-   * into {@code configuration}. Unknown keys are reported to stdout.
+   * Complexity metric keys (e.g. {@code ForLoops}) are parsed as a
+   * {@code min,max} pair into {@code complexityConfig}. Feature keys (e.g.
+   * {@code Concurrency}) are parsed as {@code ignore|require|forbid} into
+   * {@code featureConfig}. File-level settings (e.g. {@code minFileLoC},
+   * {@code useNonStdHeaders}) go into {@code config}. Path settings go into
+   * {@code configuration}. Unknown keys are reported to stdout.
    *
    * @param configFile Path to the INI-style properties file.
    */
@@ -98,55 +106,36 @@ private:
       "stdnoreturn.h", "string.h",   "tgmath.h", "threads.h",   "time.h",   "uchar.h",
       "wchar.h",       "wctype.h",   "string"};
 
-  /// Clang BuiltinType enum values for each type requested via the config's {@code type} key.
-  std::vector<unsigned int> typesRequested;
-
-  /// Human-readable names parallel to typesRequested (same index = same type).
-  std::vector<std::string> typeNames;
+  /**
+   * @brief Per-function complexity thresholds loaded from the config.
+   *
+   * Keys are complexity metric names (e.g. {@code ForLoops}); values are
+   * {@code [min, max]} pairs. Defaults are {@code {0, 99999}}, meaning no
+   * filtering unless explicitly configured.
+   */
+  std::map<std::string, std::pair<int, int>> complexityConfig = {
+      {"CallFunc", {0, 99999}}, {"ForLoops", {0, 99999}},  {"Functions", {0, 99999}},
+      {"IfStmt", {0, 99999}},   {"Param", {0, 99999}},     {"WhileLoops", {0, 99999}},
+  };
 
   /**
-   * @brief Per-function and per-file numeric thresholds loaded from the config.
+   * @brief Per-function feature gates loaded from the config.
    *
-   * Keys follow the pattern min/max + metric name (e.g. minForLoops,
-   * maxFileLoC). Defaults are 0 for minimums and 99999 for maximums, meaning
-   * no filtering unless explicitly configured.
+   * Keys are feature names (e.g. {@code Concurrency}); values say whether a
+   * function must have the feature present, must not have it, or the
+   * feature is ignored for filtering. Defaults to {@code Ignore}.
    */
-  std::map<std::string, int> config = {{"Concurrency", 0},
-                                       {"debugLevel", 0},
-                                       {"maxCallFunc", 99999},
-                                       {"maxFileLoC", 99999},
-                                       {"maxForLoops", 99999},
-                                       {"maxFunctions", 99999},
-                                       {"maxIfStmt", 99999},
-                                       {"maxParam", 99999},
-                                       {"maxTypeArithmeticOperation", 99999},
-                                       {"maxTypeCompareOperation", 99999},
-                                       {"maxTypeIfStmt", 99999},
-                                       {"maxTypeParameters", 99999},
-                                       {"maxTypePostfix", 99999},
-                                       {"maxTypePrefix", 99999},
-                                       {"maxTypeUnaryOperation", 99999},
-                                       {"maxTypeVariableReference", 99999},
-                                       {"maxTypeVariables", 99999},
-                                       {"maxWhileLoops", 99999},
-                                       {"minCallFunc", 0},
-                                       {"minFileLoC", 0},
-                                       {"minForLoops", 0},
-                                       {"minFunctions", 0},
-                                       {"minIfStmt", 0},
-                                       {"minParam", 0},
-                                       {"minTypeArithmeticOperation", 0},
-                                       {"minTypeCompareOperation", 0},
-                                       {"minTypeIfStmt", 0},
-                                       {"minTypeParameters", 0},
-                                       {"minTypePostfix", 0},
-                                       {"minTypePrefix", 0},
-                                       {"minTypeUnaryOperation", 0},
-                                       {"minTypeVariableReference", 0},
-                                       {"minTypeVariables", 0},
-                                       {"minWhileLoops", 0},
-                                       {"useNonStdHeaders", 0}};
+  std::map<std::string, FeatureGate> featureConfig = {
+      {"Concurrency", FeatureGate::Ignore},
+      {"FloatingPoint", FeatureGate::Ignore},
+  };
 
-  /// Path settings and flags that don't fit the numeric threshold map.
+  /**
+   * @brief File-level settings that aren't per-function (e.g. LoC bounds).
+   */
+  std::map<std::string, int> config = {
+      {"debugLevel", 0}, {"maxFileLoC", 99999}, {"minFileLoC", 0}, {"useNonStdHeaders", 0}};
+
+  /// Path settings and flags that don't fit either config map.
   struct filterConfigs configuration;
 };

--- a/src/filter/include/FrontendFactoryWithArgs.hpp
+++ b/src/filter/include/FrontendFactoryWithArgs.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CountingVisitor.hpp"
+
 #include <clang/Frontend/FrontendAction.h>
 #include <clang/Frontend/CompilerInvocation.h>
 #include <clang/Frontend/PCHContainerOperations.h>
@@ -9,27 +11,28 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
+#include <utility>
 
 /**
  * @brief Carries pipeline state into Clang's tool runner.
  *
  * Clang's {@code ClangTool::run()} only knows how to call {@code create()} on
- * a {@code FrontendActionFactory}. This subclass stores the config map, desired
- * types, and output stream so that each {@code FilterAction} it creates has
- * everything it needs without those objects being globals.
+ * a {@code FrontendActionFactory}. This subclass stores the config maps and
+ * output stream so that each {@code FilterAction} it creates has everything
+ * it needs without those objects being globals.
  */
 class FrontendFactoryWithArgs : public clang::tooling::FrontendActionFactory {
 public:
   /**
    * @brief Constructs the factory, binding the shared pipeline state.
    *
-   * @param config  Pointer to the threshold map owned by {@code Filterer}.
-   * @param types   Reference to the Clang BuiltinType values for requested types.
-   * @param output  Reference to the output stream for the filtered file.
+   * @param complexityConfig  Pointer to the per-metric [min, max] map owned by {@code Filterer}.
+   * @param featureConfig     Pointer to the per-feature gate map owned by {@code Filterer}.
+   * @param output            Reference to the output stream for the filtered file.
    */
-  FrontendFactoryWithArgs(std::map<std::string, int> *config,
-                          const std::vector<unsigned int> &types, llvm::raw_fd_ostream &output);
+  FrontendFactoryWithArgs(std::map<std::string, std::pair<int, int>> *complexityConfig,
+                          std::map<std::string, FeatureGate> *featureConfig,
+                          llvm::raw_fd_ostream &output);
 
   /**
    * @brief Called by {@code ClangTool} once per source file to create the action.
@@ -41,7 +44,7 @@ public:
   std::unique_ptr<clang::FrontendAction> create() override;
 
 private:
-  std::map<std::string, int> *_Config;
-  const std::vector<unsigned int> &_Types;
+  std::map<std::string, std::pair<int, int>> *_ComplexityConfig;
+  std::map<std::string, FeatureGate> *_FeatureConfig;
   llvm::raw_fd_ostream &_Output;
 };

--- a/src/full/main.cpp
+++ b/src/full/main.cpp
@@ -3,16 +3,9 @@
 #include "ClangToolUtils.hpp"
 #include <iostream>
 
-// TODO OVER HAUL THIS WHOLE THING TO MAKE SENSE AGAIN
 int main(int argc, char **argv) {
   checkClangVersion();
-  if (argc == 4) {
-    Filterer filter(argv[1]);
-    filter.run();
-
-    Transformer transformer(argv[1]);
-    transformer.run();
-  } else if (argc > 1) {
+  if (argc == 2) {
     Filterer filter(argv[1]);
     filter.run();
 
@@ -21,7 +14,7 @@ int main(int argc, char **argv) {
   } else {
     std::cout << "Incorrect Number of Args" << std::endl;
     std::cout << "Please Give the Location of the Configuration File\n"
-                 "    Example: `<filter-directory> <config-file> <Resource-Dir>`"
+                 "    Example: `./build/full <config-file>`"
               << std::endl;
     return 1;
   }

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -254,6 +254,9 @@ void __VERIFIER_nondet_memory(void *mem, size_t size) {
 void reach_error(void) {}
 )";
 
+// NOTE: cmd is passed to std::system (shell-interpreted), and path/verifierPath
+// are not escaped. path originates from a cloned/downloaded repository, so a
+// pathological filename containing shell metacharacters could inject commands
 int Transformer::checkCompilable(std::filesystem::path path) {
   std::optional<std::string> resourceDir = getResourceDir();
   if (!resourceDir)
@@ -333,6 +336,7 @@ void Transformer::writeBenchmarkTask(std::filesystem::path cPath) {
       << "  data_model: LP64\n";
 }
 
+// NOTE: same std::system/unescaped-path caveat as checkCompilable above.
 bool Transformer::preprocess(std::filesystem::path cPath) {
   std::filesystem::path iPath = cPath;
   iPath.replace_extension(".i");

--- a/src/transform/main.cpp
+++ b/src/transform/main.cpp
@@ -8,12 +8,10 @@ int main(int argc, char **argv) {
   if (argc == 2) {
     Transformer transformer(argv[1]);
     transformer.run();
-  } else if (argc > 1) {
-    Transformer transformer(argv[1]);
-    transformer.run();
   } else {
     std::cout << "Incorrect Number of Args" << std::endl;
     std::cout << "Please Give the Location of the Configuration File" << std::endl;
+    return 1;
   }
-  return 1;
+  return 0;
 }

--- a/tests/filter/CountingVisitorTest.cpp
+++ b/tests/filter/CountingVisitorTest.cpp
@@ -26,9 +26,8 @@ struct CountResult {
       std::make_shared<std::unordered_map<std::string, CountingVisitor::attributes>>();
 };
 
-// Parse `code` as C and run CountingVisitor with the given type filter.
-// Pass an empty `types` vector to count all types (the _allTypes fast-path).
-static CountResult runCounter(const std::string &code, std::vector<unsigned int> types = {}) {
+// Parse `code` as C and run CountingVisitor over it.
+static CountResult runCounter(const std::string &code) {
   CountResult r;
 
   // "-xc" tells clang to treat the string as a C file rather than C++.
@@ -38,7 +37,7 @@ static CountResult runCounter(const std::string &code, std::vector<unsigned int>
   if (!r.ast)
     return r;
 
-  CountingVisitor visitor(&r.ast->getASTContext(), types, r.funcs);
+  CountingVisitor visitor(&r.ast->getASTContext(), r.funcs);
   visitor.TraverseTranslationUnitDecl(r.ast->getASTContext().getTranslationUnitDecl());
 
   return r;
@@ -64,7 +63,7 @@ static CountResult runCounter(const std::string &code, std::vector<unsigned int>
 TEST(CountingVisitor, ForLoopInFunction) {
   auto r = runCounter("void foo() { for(int i=0;i<10;i++){} }");
   ASSERT_TRUE(r.funcs->count("foo")) << "function 'foo' not registered";
-  EXPECT_EQ(r.funcs->at("foo").ForLoops, 1);
+  EXPECT_EQ(r.funcs->at("foo").Complexity.ForLoops, 1);
 }
 
 TEST(CountingVisitor, MultipleForLoops) {
@@ -75,13 +74,13 @@ TEST(CountingVisitor, MultipleForLoops) {
     }
   )");
   ASSERT_TRUE(r.funcs->count("foo"));
-  EXPECT_EQ(r.funcs->at("foo").ForLoops, 2);
+  EXPECT_EQ(r.funcs->at("foo").Complexity.ForLoops, 2);
 }
 
 TEST(CountingVisitor, WhileLoopInFunction) {
   auto r = runCounter("void foo() { int x=0; while(x<10){x++;} }");
   ASSERT_TRUE(r.funcs->count("foo"));
-  EXPECT_EQ(r.funcs->at("foo").WhileLoops, 1);
+  EXPECT_EQ(r.funcs->at("foo").Complexity.WhileLoops, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -91,16 +90,7 @@ TEST(CountingVisitor, WhileLoopInFunction) {
 TEST(CountingVisitor, IfStmt) {
   auto r = runCounter("void foo(int x) { if(x>0){} }");
   ASSERT_TRUE(r.funcs->count("foo"));
-  EXPECT_EQ(r.funcs->at("foo").IfStmt, 1);
-}
-
-TEST(CountingVisitor, TypeIfStmtIntCondition) {
-  // TypeIfStmt counts ifs whose condition is of a requested type.
-  // We ask for int (BuiltinType::Int = 17).
-  auto r = runCounter("void foo(int x) { if(x>0){} }", {clang::BuiltinType::Int});
-  ASSERT_TRUE(r.funcs->count("foo"));
-  EXPECT_EQ(r.funcs->at("foo").IfStmt, 1);
-  EXPECT_EQ(r.funcs->at("foo").TypeIfStmt, 1);
+  EXPECT_EQ(r.funcs->at("foo").Complexity.IfStmt, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -112,13 +102,21 @@ TEST(CountingVisitor, FunctionCountInProgram) {
   // Each unique function declaration increments Program.Functions.
   auto r = runCounter("void foo(){} void bar(){}");
   ASSERT_TRUE(r.funcs->count("Program"));
-  EXPECT_EQ(r.funcs->at("Program").Functions, 2);
+  EXPECT_EQ(r.funcs->at("Program").Complexity.Functions, 2);
 }
 
 TEST(CountingVisitor, EachFunctionGetsItsOwnEntry) {
   auto r = runCounter("void foo(){} void bar(){}");
   EXPECT_TRUE(r.funcs->count("foo"));
   EXPECT_TRUE(r.funcs->count("bar"));
+}
+
+TEST(CountingVisitor, ParamCountPerFunction) {
+  auto r = runCounter("void foo(int a, int b, int c){} void bar(void){}");
+  ASSERT_TRUE(r.funcs->count("foo"));
+  ASSERT_TRUE(r.funcs->count("bar"));
+  EXPECT_EQ(r.funcs->at("foo").Complexity.Param, 3);
+  EXPECT_EQ(r.funcs->at("bar").Complexity.Param, 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -131,25 +129,7 @@ TEST(CountingVisitor, CallFuncCount) {
     void foo() { helper(); helper(); }
   )");
   ASSERT_TRUE(r.funcs->count("foo"));
-  EXPECT_EQ(r.funcs->at("foo").CallFunc, 2);
-}
-
-// ---------------------------------------------------------------------------
-// Variable counting (type-filtered)
-// ---------------------------------------------------------------------------
-
-TEST(CountingVisitor, TypeVariablesCountsOnlyMatchingType) {
-  // Only int variables should be counted when we filter for int.
-  auto r = runCounter("void foo() { int x; float y; int z; }", {clang::BuiltinType::Int});
-  ASSERT_TRUE(r.funcs->count("foo"));
-  EXPECT_EQ(r.funcs->at("foo").TypeVariables, 2); // x and z
-}
-
-TEST(CountingVisitor, TypeVariablesAllTypesWhenFilterEmpty) {
-  // Empty types vector → _allTypes = true → count every variable
-  auto r = runCounter("void foo() { int x; float y; }");
-  ASSERT_TRUE(r.funcs->count("foo"));
-  EXPECT_EQ(r.funcs->at("foo").TypeVariables, 2);
+  EXPECT_EQ(r.funcs->at("foo").Complexity.CallFunc, 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -163,18 +143,8 @@ TEST(CountingVisitor, CountsAreIsolatedPerFunction) {
   )");
   ASSERT_TRUE(r.funcs->count("foo"));
   ASSERT_TRUE(r.funcs->count("bar"));
-  EXPECT_EQ(r.funcs->at("foo").ForLoops, 1);
-  EXPECT_EQ(r.funcs->at("bar").ForLoops, 0);
-}
-
-// ---------------------------------------------------------------------------
-// Binary operators
-// ---------------------------------------------------------------------------
-
-TEST(CountingVisitor, ComparisonOperatorCounted) {
-  auto r = runCounter("void foo(int x) { int y = x > 0; }", {clang::BuiltinType::Int});
-  ASSERT_TRUE(r.funcs->count("foo"));
-  EXPECT_EQ(r.funcs->at("foo").TypeCompareOperation, 1);
+  EXPECT_EQ(r.funcs->at("foo").Complexity.ForLoops, 1);
+  EXPECT_EQ(r.funcs->at("bar").Complexity.ForLoops, 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +177,7 @@ TEST(CountingVisitor, ConcurrencyFlaggedForLocalPthreadVariable) {
     }
   )");
   ASSERT_TRUE(r.funcs->count("worker"));
-  EXPECT_TRUE(r.funcs->at("worker").Concurrency);
+  EXPECT_TRUE(r.funcs->at("worker").Features.Concurrency);
 }
 
 TEST(CountingVisitor, ConcurrencyFlaggedByCallArgumentAlone) {
@@ -221,7 +191,7 @@ TEST(CountingVisitor, ConcurrencyFlaggedByCallArgumentAlone) {
     }
   )");
   ASSERT_TRUE(r.funcs->count("worker"));
-  EXPECT_TRUE(r.funcs->at("worker").Concurrency);
+  EXPECT_TRUE(r.funcs->at("worker").Features.Concurrency);
 }
 
 TEST(CountingVisitor, ConcurrencyFlaggedForPointerTypedLocal) {
@@ -233,7 +203,7 @@ TEST(CountingVisitor, ConcurrencyFlaggedForPointerTypedLocal) {
     }
   )");
   ASSERT_TRUE(r.funcs->count("worker"));
-  EXPECT_TRUE(r.funcs->at("worker").Concurrency);
+  EXPECT_TRUE(r.funcs->at("worker").Features.Concurrency);
 }
 
 TEST(CountingVisitor, ConcurrencyNotSetForCleanFunction) {
@@ -244,7 +214,7 @@ TEST(CountingVisitor, ConcurrencyNotSetForCleanFunction) {
     }
   )");
   ASSERT_TRUE(r.funcs->count("clean"));
-  EXPECT_FALSE(r.funcs->at("clean").Concurrency);
+  EXPECT_FALSE(r.funcs->at("clean").Features.Concurrency);
 }
 
 TEST(CountingVisitor, ConcurrencyIsolatedPerFunction) {
@@ -259,6 +229,45 @@ TEST(CountingVisitor, ConcurrencyIsolatedPerFunction) {
   )");
   ASSERT_TRUE(r.funcs->count("worker"));
   ASSERT_TRUE(r.funcs->count("clean"));
-  EXPECT_TRUE(r.funcs->at("worker").Concurrency);
-  EXPECT_FALSE(r.funcs->at("clean").Concurrency);
+  EXPECT_TRUE(r.funcs->at("worker").Features.Concurrency);
+  EXPECT_FALSE(r.funcs->at("clean").Features.Concurrency);
+}
+
+// ---------------------------------------------------------------------------
+// Floating-point detection — tracked but not yet enforced by the filter.
+// ---------------------------------------------------------------------------
+
+TEST(CountingVisitor, FloatingPointFlaggedForLocalFloatVariable) {
+  auto r = runCounter("void foo() { float x = 1.0f; }");
+  ASSERT_TRUE(r.funcs->count("foo"));
+  EXPECT_TRUE(r.funcs->at("foo").Features.FloatingPoint);
+}
+
+TEST(CountingVisitor, FloatingPointFlaggedForDoubleParam) {
+  auto r = runCounter("void foo(double x) {}");
+  ASSERT_TRUE(r.funcs->count("foo"));
+  EXPECT_TRUE(r.funcs->at("foo").Features.FloatingPoint);
+}
+
+TEST(CountingVisitor, FloatingPointFlaggedForFloatReturnType) {
+  auto r = runCounter("float foo(int x) { return x; }");
+  ASSERT_TRUE(r.funcs->count("foo"));
+  EXPECT_TRUE(r.funcs->at("foo").Features.FloatingPoint);
+}
+
+TEST(CountingVisitor, FloatingPointNotSetForIntOnlyFunction) {
+  auto r = runCounter("int foo(int x) { int y = x + 1; return y; }");
+  ASSERT_TRUE(r.funcs->count("foo"));
+  EXPECT_FALSE(r.funcs->at("foo").Features.FloatingPoint);
+}
+
+TEST(CountingVisitor, FloatingPointIsolatedPerFunction) {
+  auto r = runCounter(R"(
+    void withFloat() { float x = 1.0f; }
+    int clean(int x) { return x + 1; }
+  )");
+  ASSERT_TRUE(r.funcs->count("withFloat"));
+  ASSERT_TRUE(r.funcs->count("clean"));
+  EXPECT_TRUE(r.funcs->at("withFloat").Features.FloatingPoint);
+  EXPECT_FALSE(r.funcs->at("clean").Features.FloatingPoint);
 }

--- a/tests/filter/FilterFunctionsConsumerTest.cpp
+++ b/tests/filter/FilterFunctionsConsumerTest.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 // ---------------------------------------------------------------------------
@@ -23,41 +24,21 @@
 
 namespace {
 
-// Mirrors Filterer's default threshold map: every max is permissive (99999)
-// and every min is permissive (0), so a test only needs to override the one
-// or two keys it cares about.
-std::map<std::string, int> permissiveConfig() {
-  return {{"Concurrency", 0},
-          {"maxCallFunc", 99999},
-          {"maxForLoops", 99999},
-          {"maxFunctions", 99999},
-          {"maxIfStmt", 99999},
-          {"maxParam", 99999},
-          {"maxTypeArithmeticOperation", 99999},
-          {"maxTypeCompareOperation", 99999},
-          {"maxTypeIfStmt", 99999},
-          {"maxTypeParameters", 99999},
-          {"maxTypePostfix", 99999},
-          {"maxTypePrefix", 99999},
-          {"maxTypeUnaryOperation", 99999},
-          {"maxTypeVariableReference", 99999},
-          {"maxTypeVariables", 99999},
-          {"maxWhileLoops", 99999},
-          {"minCallFunc", 0},
-          {"minForLoops", 0},
-          {"minFunctions", 0},
-          {"minIfStmt", 0},
-          {"minParam", 0},
-          {"minTypeArithmeticOperation", 0},
-          {"minTypeCompareOperation", 0},
-          {"minTypeIfStmt", 0},
-          {"minTypeParameters", 0},
-          {"minTypePostfix", 0},
-          {"minTypePrefix", 0},
-          {"minTypeUnaryOperation", 0},
-          {"minTypeVariableReference", 0},
-          {"minTypeVariables", 0},
-          {"minWhileLoops", 0}};
+// Mirrors Filterer's default config: every complexity range is permissive
+// ([0, 99999]) and every feature gate is Ignore, so a test only needs to
+// override the one or two keys it cares about.
+std::map<std::string, std::pair<int, int>> permissiveComplexityConfig() {
+  return {
+      {"CallFunc", {0, 99999}}, {"ForLoops", {0, 99999}},  {"Functions", {0, 99999}},
+      {"IfStmt", {0, 99999}},   {"Param", {0, 99999}},     {"WhileLoops", {0, 99999}},
+  };
+}
+
+std::map<std::string, FeatureGate> permissiveFeatureConfig() {
+  return {
+      {"Concurrency", FeatureGate::Ignore},
+      {"FloatingPoint", FeatureGate::Ignore},
+  };
 }
 
 struct FilterResult {
@@ -69,19 +50,21 @@ struct FilterResult {
 };
 
 // Parses `code`, runs CountingVisitor to populate real attribute counts, then
-// runs FilterFunctionsConsumer with `config` and returns what ended up in
-// _ToRemove.
-FilterResult runFilter(const std::string &code, std::map<std::string, int> config) {
+// runs FilterFunctionsConsumer with the given configs and returns what ended
+// up in _ToRemove.
+FilterResult runFilter(const std::string &code,
+                       std::map<std::string, std::pair<int, int>> complexityConfig,
+                       std::map<std::string, FeatureGate> featureConfig) {
   FilterResult r;
   r.ast = clang::tooling::buildASTFromCodeWithArgs(code, {"-xc"}, "test.c");
   EXPECT_NE(r.ast, nullptr) << "AST failed to build for:\n" << code;
   if (!r.ast)
     return r;
 
-  CountingVisitor counter(&r.ast->getASTContext(), {}, r.funcs);
+  CountingVisitor counter(&r.ast->getASTContext(), r.funcs);
   counter.TraverseTranslationUnitDecl(r.ast->getASTContext().getTranslationUnitDecl());
 
-  FilterFunctionsConsumer filterConsumer(r.funcs, r.toRemove, &config);
+  FilterFunctionsConsumer filterConsumer(r.funcs, r.toRemove, &complexityConfig, &featureConfig);
   filterConsumer.FilterFunctions(r.ast->getASTContext());
 
   return r;
@@ -97,11 +80,11 @@ bool contains(const std::vector<std::string> &v, const std::string &name) {
 // main + concurrency
 // ---------------------------------------------------------------------------
 
-TEST(FilterFunctionsConsumer, MainRemovedWhenConcurrencyFlagged) {
+TEST(FilterFunctionsConsumer, MainRemovedWhenConcurrencyRequired) {
   // pthread_create() called directly inside main (no helper function) — this
   // is exactly the case that used to slip through filtering untouched.
-  auto config = permissiveConfig();
-  config["Concurrency"] = 1;
+  auto features = permissiveFeatureConfig();
+  features["Concurrency"] = FeatureGate::Forbid;
   auto r = runFilter(R"(
     typedef unsigned long pthread_t;
     int pthread_create(pthread_t *t, void *attr, void *(*fn)(void *), void *arg);
@@ -112,14 +95,13 @@ TEST(FilterFunctionsConsumer, MainRemovedWhenConcurrencyFlagged) {
       return 0;
     }
   )",
-                       config);
+                       permissiveComplexityConfig(), features);
   EXPECT_TRUE(contains(*r.toRemove, "main"));
 }
 
-TEST(FilterFunctionsConsumer, MainKeptWhenConcurrencyCheckDisabled) {
-  // Same body as above, but Concurrency=0 (the default) means the check is
-  // off entirely — main should survive untouched.
-  auto config = permissiveConfig();
+TEST(FilterFunctionsConsumer, MainKeptWhenConcurrencyIgnored) {
+  // Same body as above, but Concurrency=Ignore (the default) means the check
+  // is off entirely — main should survive untouched.
   auto r = runFilter(R"(
     typedef unsigned long pthread_t;
     int pthread_create(pthread_t *t, void *attr, void *(*fn)(void *), void *arg);
@@ -130,7 +112,7 @@ TEST(FilterFunctionsConsumer, MainKeptWhenConcurrencyCheckDisabled) {
       return 0;
     }
   )",
-                       config);
+                       permissiveComplexityConfig(), permissiveFeatureConfig());
   EXPECT_FALSE(contains(*r.toRemove, "main"));
 }
 
@@ -142,27 +124,26 @@ TEST(FilterFunctionsConsumer, MainRemovedByOrdinaryThresholdCheck) {
   // main is no longer blanket-exempt from the general min/max ladder — a
   // for-loop count over the configured max should remove it just like any
   // other function.
-  auto config = permissiveConfig();
-  config["maxForLoops"] = 0;
+  auto complexity = permissiveComplexityConfig();
+  complexity["ForLoops"] = {0, 0};
   auto r = runFilter(R"(
     int main(void) {
       for (int i = 0; i < 10; i++) {}
       return 0;
     }
   )",
-                       config);
+                       complexity, permissiveFeatureConfig());
   EXPECT_TRUE(contains(*r.toRemove, "main"));
 }
 
 TEST(FilterFunctionsConsumer, MainKeptWhenThresholdsSatisfied) {
-  auto config = permissiveConfig();
   auto r = runFilter(R"(
     int main(void) {
       for (int i = 0; i < 10; i++) {}
       return 0;
     }
   )",
-                       config);
+                       permissiveComplexityConfig(), permissiveFeatureConfig());
   EXPECT_FALSE(contains(*r.toRemove, "main"));
 }
 
@@ -175,13 +156,12 @@ TEST(FilterFunctionsConsumer, MainNotRemovedForUnsupportedArgvParam) {
   // function with this param type would be removed by the trailing
   // param-type check, but main is exempt from that specific check since
   // MainGenConsumer handles argc/argv itself.
-  auto config = permissiveConfig();
   auto r = runFilter(R"(
     int main(int argc, char **argv) {
       return argc;
     }
   )",
-                       config);
+                       permissiveComplexityConfig(), permissiveFeatureConfig());
   EXPECT_FALSE(contains(*r.toRemove, "main"));
 }
 
@@ -189,12 +169,11 @@ TEST(FilterFunctionsConsumer, OrdinaryFunctionRemovedForUnsupportedParam) {
   // Sanity check that the param-type check still fires normally for
   // non-main functions, so the main exemption above is verified against a
   // real contrast rather than a check that never removes anything.
-  auto config = permissiveConfig();
   auto r = runFilter(R"(
     int main(void) { return 0; }
     void helper(char **argv) {}
   )",
-                       config);
+                       permissiveComplexityConfig(), permissiveFeatureConfig());
   EXPECT_TRUE(contains(*r.toRemove, "helper"));
   EXPECT_FALSE(contains(*r.toRemove, "main"));
 }


### PR DESCRIPTION
Per #61 updates to the property configuration file. Type-specific metrics removed and syntax switched to 'min,max' range instead of separate. Metric split into complexity (for structural characteristics), and features (for categorical). Features use flags for inclusion and exclusion though currently there are two features (floating point, concurrency) tracked and the latter, only for exclusion. Future support for more granular evaluation of these features can be considered as necessary.