### PR TITLE
Identify and remove dead code

### DIFF
--- a/src/transform/HavocCallsConsumer.cpp
+++ b/src/transform/HavocCallsConsumer.cpp
@@ -2,13 +2,34 @@
 #include "HavocCallsVisitor.hpp"
 
 #include <clang/AST/ASTContext.h>
+#include <clang/AST/Decl.h>
+#include <clang/AST/DeclBase.h>
+#include <clang/Basic/SourceManager.h>
 #include <clang/Rewrite/Core/Rewriter.h>
+#include <llvm/Support/Casting.h>
 
 HavocCallsConsumer::HavocCallsConsumer(std::shared_ptr<std::set<std::string>> neededSuffixes,
+                                       std::shared_ptr<std::set<std::string>> noOpFunctions,
                                        clang::Rewriter &rewriter)
-    : _NeededSuffixes(neededSuffixes), _Rewriter(rewriter) {}
+    : _NeededSuffixes(neededSuffixes), _NoOpFunctions(noOpFunctions), _Rewriter(rewriter) {}
 
 void HavocCallsConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
   HavocCallsVisitor Visitor(&Context, _NeededSuffixes, _Rewriter);
   Visitor.VisitTranslationUnit(Context.getTranslationUnitDecl());
+
+  // Strip any function whose body collapsed entirely to no-ops
+  clang::SourceManager &mgr = Context.getSourceManager();
+  for (clang::Decl *decl : Context.getTranslationUnitDecl()->decls()) {
+    const auto *func = llvm::dyn_cast<clang::FunctionDecl>(decl);
+    if (!func || !mgr.isInMainFile(func->getLocation()))
+      continue;
+    if (!func->isThisDeclarationADefinition() || func->getLocation().isMacroID())
+      continue;
+    if (!Visitor.isNoOp(func->getBody()))
+      continue;
+    clang::SourceRange bodyRange = func->getBody()->getSourceRange();
+    if (bodyRange.isValid())
+      _Rewriter.ReplaceText(bodyRange, ";");
+    _NoOpFunctions->insert(func->getNameAsString());
+  }
 }

--- a/src/transform/HavocCallsVisitor.cpp
+++ b/src/transform/HavocCallsVisitor.cpp
@@ -4,10 +4,81 @@
 
 #include <clang/AST/DeclBase.h>
 #include <clang/AST/Expr.h>
+#include <clang/AST/OperationKinds.h>
 #include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/AST/Stmt.h>
 #include <clang/Basic/SourceManager.h>
 #include <clang/Rewrite/Core/Rewriter.h>
 #include <optional>
+
+namespace {
+
+// Conservative purity check used to decide whether an `if` condition can be
+// dropped along with its (now no-op) branches. Anything not explicitly
+// recognized here — calls, overloaded operators, volatile accesses, etc. —
+// is treated as side-effecting, so we only ever prune conditionals we can
+// prove are safe to remove.
+bool isSideEffectFree(const clang::Expr *E) {
+  if (!E)
+    return true;
+  E = E->IgnoreParenCasts();
+  switch (E->getStmtClass()) {
+  case clang::Stmt::DeclRefExprClass:
+  case clang::Stmt::IntegerLiteralClass:
+  case clang::Stmt::FloatingLiteralClass:
+  case clang::Stmt::CharacterLiteralClass:
+  case clang::Stmt::StringLiteralClass:
+  case clang::Stmt::GNUNullExprClass:
+  case clang::Stmt::UnaryExprOrTypeTraitExprClass: // sizeof / alignof
+    return true;
+  case clang::Stmt::UnaryOperatorClass: {
+    const auto *UO = clang::cast<clang::UnaryOperator>(E);
+    if (UO->isIncrementDecrementOp())
+      return false;
+    return isSideEffectFree(UO->getSubExpr());
+  }
+  case clang::Stmt::BinaryOperatorClass: {
+    const auto *BO = clang::cast<clang::BinaryOperator>(E);
+    if (BO->isAssignmentOp())
+      return false;
+    return isSideEffectFree(BO->getLHS()) && isSideEffectFree(BO->getRHS());
+  }
+  case clang::Stmt::ConditionalOperatorClass: {
+    const auto *CO = clang::cast<clang::ConditionalOperator>(E);
+    return isSideEffectFree(CO->getCond()) && isSideEffectFree(CO->getTrueExpr()) &&
+           isSideEffectFree(CO->getFalseExpr());
+  }
+  case clang::Stmt::MemberExprClass:
+    return isSideEffectFree(clang::cast<clang::MemberExpr>(E)->getBase());
+  case clang::Stmt::ArraySubscriptExprClass: {
+    const auto *AS = clang::cast<clang::ArraySubscriptExpr>(E);
+    return isSideEffectFree(AS->getBase()) && isSideEffectFree(AS->getIdx());
+  }
+  default:
+    return false;
+  }
+}
+
+// A `for` loop's init clause is a statement, not an expression: either a
+// bare expression-statement or a declaration (`for (int i = 0; ...)`). A
+// loop-scoped declaration with a side-effect-free initializer is itself
+// side-effect-free, since the variable it introduces cannot be observed
+// outside the loop.
+bool isInitSideEffectFree(const clang::Stmt *init) {
+  if (!init)
+    return true;
+  if (const auto *declStmt = clang::dyn_cast<clang::DeclStmt>(init)) {
+    if (!declStmt->isSingleDecl())
+      return false;
+    const auto *VD = clang::dyn_cast<clang::VarDecl>(declStmt->getSingleDecl());
+    return VD && isSideEffectFree(VD->getInit());
+  }
+  if (const auto *E = clang::dyn_cast<clang::Expr>(init))
+    return isSideEffectFree(E);
+  return false;
+}
+
+} // namespace
 
 HavocCallsVisitor::HavocCallsVisitor(clang::ASTContext *C,
                                      std::shared_ptr<std::set<std::string>> neededSuffixes,
@@ -48,8 +119,10 @@ bool HavocCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
     return clang::RecursiveASTVisitor<HavocCallsVisitor>::VisitCallExpr(E);
   if (returnType->isVoidType()) {
     // A void call yields no value to havoc; drop it (the statement's
-    // semicolon stays behind, leaving an empty statement)
+    // semicolon stays behind, leaving an empty statement). Mark it a no-op so
+    // an enclosing if-branch made up only of dropped calls can be pruned too.
     _Rewriter.ReplaceText(E->getSourceRange(), "");
+    _NoOpStmts.insert(E);
   } else if (std::optional<std::string> suffix = verifierSuffixForType(returnType)) {
     _Rewriter.ReplaceText(E->getSourceRange(), "__VERIFIER_nondet_" + *suffix + "()");
     _NeededSuffixes->emplace(*suffix);
@@ -64,12 +137,81 @@ bool HavocCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
     // return type so e.g. unsigned char* or a struct pointer doesn't end up
     // assigned from an incompatible pointer type.
     _Rewriter.ReplaceText(E->getSourceRange(),
-                           "(" + returnType.getAsString() + ")" + helper + "(128)");
+                          "(" + returnType.getAsString() + ")" + helper + "(128)");
     _NeededSuffixes->emplace(helper);
   }
   // Aggregate returns (structs, unions) have no expression-position nondet
   // equivalent; those calls are left as-is
   return clang::RecursiveASTVisitor<HavocCallsVisitor>::VisitCallExpr(E);
+}
+
+bool HavocCallsVisitor::isNoOp(const clang::Stmt *S) const {
+  if (!S || clang::isa<clang::NullStmt>(S))
+    return true;
+  return _NoOpStmts.count(S) != 0;
+}
+
+bool HavocCallsVisitor::VisitCompoundStmt(clang::CompoundStmt *S) {
+  for (const clang::Stmt *child : S->body()) {
+    if (!isNoOp(child))
+      return true;
+  }
+  // Empty blocks fall through the loop above and are no-ops too.
+  _NoOpStmts.insert(S);
+  return true;
+}
+
+// Shared prune rule for if/while/do/for: if every branch/body is already a
+// no-op and every controlling expression (condition, plus a for-loop's init
+// and increment) is side-effect-free, erase the whole statement and mark it
+// a no-op so the pruning can propagate to an enclosing statement. `init` and
+// `inc` are unused (default null, trivially side-effect-free) outside
+// VisitForStmt.
+//
+// For `if`, this can never change whether the program terminates — dropping
+// a dead branch doesn't create or remove divergence. For loops it can: an
+// empty body spinning on a side-effect-free condition (`while (n > 0);`) may
+// hang, and pruning it turns that hang into termination. That's intentional
+// here — such loops are havoc artifacts, not meaningful termination-
+// benchmark content. A condition/increment with a real side effect (e.g.
+// `while (x-- > 0);`) is kept regardless, since `x` may be observed after
+// the loop.
+bool HavocCallsVisitor::pruneIfNoOp(clang::Stmt *S, clang::SourceLocation keyLoc,
+                                    std::initializer_list<const clang::Stmt *> branches,
+                                    const clang::Expr *cond, const clang::Stmt *init,
+                                    const clang::Expr *inc) {
+  clang::SourceManager &mgr = _C->getSourceManager();
+  if (!mgr.isInMainFile(keyLoc) || keyLoc.isMacroID())
+    return false;
+  for (const clang::Stmt *branch : branches) {
+    if (!isNoOp(branch))
+      return false;
+  }
+  if (!isSideEffectFree(cond) || !isInitSideEffectFree(init) || !isSideEffectFree(inc))
+    return false;
+  _Rewriter.ReplaceText(S->getSourceRange(), "");
+  _NoOpStmts.insert(S);
+  return true;
+}
+
+bool HavocCallsVisitor::VisitIfStmt(clang::IfStmt *S) {
+  pruneIfNoOp(S, S->getIfLoc(), {S->getThen(), S->getElse()}, S->getCond());
+  return true;
+}
+
+bool HavocCallsVisitor::VisitWhileStmt(clang::WhileStmt *S) {
+  pruneIfNoOp(S, S->getWhileLoc(), {S->getBody()}, S->getCond());
+  return true;
+}
+
+bool HavocCallsVisitor::VisitDoStmt(clang::DoStmt *S) {
+  pruneIfNoOp(S, S->getDoLoc(), {S->getBody()}, S->getCond());
+  return true;
+}
+
+bool HavocCallsVisitor::VisitForStmt(clang::ForStmt *S) {
+  pruneIfNoOp(S, S->getForLoc(), {S->getBody()}, S->getCond(), S->getInit(), S->getInc());
+  return true;
 }
 
 bool HavocCallsVisitor::shouldTraversePostOrder() { return true; }

--- a/src/transform/MainGenConsumer.cpp
+++ b/src/transform/MainGenConsumer.cpp
@@ -12,8 +12,9 @@
 #include <vector>
 
 MainGenConsumer::MainGenConsumer(std::shared_ptr<std::set<std::string>> neededSuffixes,
+                                 std::shared_ptr<std::set<std::string>> noOpFunctions,
                                  clang::Rewriter &rewriter)
-    : _NeededSuffixes(neededSuffixes), _Rewriter(rewriter) {}
+    : _NeededSuffixes(neededSuffixes), _NoOpFunctions(noOpFunctions), _Rewriter(rewriter) {}
 
 void MainGenConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
   clang::SourceManager &mgr = Context.getSourceManager();
@@ -35,8 +36,13 @@ void MainGenConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
 
   std::string harness;
   for (const clang::FunctionDecl *func : defined) {
+    if (_NoOpFunctions->count(func->getNameAsString())) {
+      debugLog(2, "Info: " + func->getNameAsString() + " body collapsed to no-ops; not harnessed");
+      continue;
+    }
     // main has a known pointer contract (argc/argv), so synthesize a real
     // call instead of skipping it like an arbitrary unsupported-param function
+    // (note no-op supercedes this)
     if (func->isMain()) {
       harness += genMainHarness(func);
       continue;

--- a/src/transform/TransformAction.cpp
+++ b/src/transform/TransformAction.cpp
@@ -50,10 +50,15 @@ TransformAction::CreateASTConsumer(clang::CompilerInstance &compiler, llvm::Stri
   // Verifier suffixes needed by call havocking and the generated main;
   // AddVerifiersConsumer runs last and emits the extern declarations
   auto neededSuffixes = std::make_shared<std::set<std::string>>();
+  // Functions HavocCallsConsumer found to have collapsed entirely to no-ops;
+  // MainGenConsumer skips harnessing them
+  auto noOpFunctions = std::make_shared<std::set<std::string>>();
 
   std::vector<std::unique_ptr<clang::ASTConsumer>> tempVector;
-  tempVector.emplace_back(std::make_unique<HavocCallsConsumer>(neededSuffixes, _Rewriter));
-  tempVector.emplace_back(std::make_unique<MainGenConsumer>(neededSuffixes, _Rewriter));
+  tempVector.emplace_back(
+      std::make_unique<HavocCallsConsumer>(neededSuffixes, noOpFunctions, _Rewriter));
+  tempVector.emplace_back(
+      std::make_unique<MainGenConsumer>(neededSuffixes, noOpFunctions, _Rewriter));
   tempVector.emplace_back(std::make_unique<AddVerifiersConsumer>(neededSuffixes, _Rewriter));
   tempVector.emplace_back(std::make_unique<AddStdIncludesConsumer>(existingIncludes, _Rewriter));
 

--- a/src/transform/include/HavocCallsConsumer.hpp
+++ b/src/transform/include/HavocCallsConsumer.hpp
@@ -14,6 +14,11 @@
  * a nondeterministic value of the appropriate return type, making each function
  * body intraprocedural. The set of verifier suffixes used is recorded in
  * {@code neededSuffixes} for {@code AddVerifiersConsumer} to declare.
+ *
+ * After traversal, any function whose body collapsed entirely to no-ops
+ * (e.g. a void wrapper whose only calls were themselves dropped) is stripped
+ * to a bare declaration and its name recorded in {@code noOpFunctions}, so
+ * {@code MainGenConsumer} does not bother harnessing it.
  */
 class HavocCallsConsumer : public clang::ASTConsumer {
 public:
@@ -22,13 +27,17 @@ public:
    *
    * @param neededSuffixes Output set; verifier suffixes needed by havoc
    *        replacements are inserted here.
+   * @param noOpFunctions  Output set; names of functions whose bodies
+   *        collapsed entirely to no-ops are inserted here.
    * @param rewriter       Shared rewriter for modifying the source buffer.
    */
   HavocCallsConsumer(std::shared_ptr<std::set<std::string>> neededSuffixes,
+                     std::shared_ptr<std::set<std::string>> noOpFunctions,
                      clang::Rewriter &rewriter);
 
   /**
-   * @brief Launches {@code HavocCallsVisitor} and populates the suffix set.
+   * @brief Launches {@code HavocCallsVisitor}, populates the suffix set, and
+   * strips any function whose body ended up entirely a no-op.
    *
    * @param Context The AST context for the translation unit being transformed.
    */
@@ -36,5 +45,6 @@ public:
 
 private:
   std::shared_ptr<std::set<std::string>> _NeededSuffixes;
+  std::shared_ptr<std::set<std::string>> _NoOpFunctions;
   clang::Rewriter &_Rewriter;
 };

--- a/src/transform/include/HavocCallsVisitor.hpp
+++ b/src/transform/include/HavocCallsVisitor.hpp
@@ -4,7 +4,9 @@
 #include <clang/AST/Decl.h>
 #include <clang/AST/DeclBase.h>
 #include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/AST/Stmt.h>
 #include <clang/Rewrite/Core/Rewriter.h>
+#include <initializer_list>
 #include <memory>
 #include <set>
 #include <string>
@@ -20,9 +22,9 @@
  * - {@code void} returns → call is dropped
  * - Aggregate returns (structs, unions) → left as-is
  *
- * Library calls (C stdlib, system headers) and {@code __VERIFIER_*} calls are
- * kept unchanged. Calls inside macro expansions are skipped (no rewritable
- * source range).
+ * Dropped calls are marked as no-ops and enclosures checked for removal
+ * so that if any loops or branches are side effect free and contain only
+ * no-ops they are removed
  */
 class HavocCallsVisitor : public clang::RecursiveASTVisitor<HavocCallsVisitor> {
 public:
@@ -67,14 +69,97 @@ public:
   virtual bool VisitCallExpr(clang::CallExpr *E);
 
   /**
-   * @brief Instructs the visitor to use post-order (depth-first) traversal.
+   * @brief Marks an empty compound statement, or one whose entire body is
+   * made up of no-op statements, as itself a no-op.
    *
+   * @param S The compound statement being visited.
+   * @return {@code true} to continue traversal.
+   */
+  virtual bool VisitCompoundStmt(clang::CompoundStmt *S);
+
+  /**
+   * @brief Erases an {@code if} statement whose branches are all no-ops and
+   * whose condition is side-effect-free, then marks it as a no-op so removal
+   * propagates to enclosing statements. See {@code pruneIfNoOp}.
+   *
+   * @param S The if statement being visited.
+   * @return {@code true} to continue traversal.
+   */
+  virtual bool VisitIfStmt(clang::IfStmt *S);
+
+  /**
+   * @brief Erases a {@code while} loop whose body is a no-op and whose
+   * condition is side-effect-free. See {@code pruneIfNoOp}.
+   *
+   * @param S The while statement being visited.
+   * @return {@code true} to continue traversal.
+   */
+  virtual bool VisitWhileStmt(clang::WhileStmt *S);
+
+  /**
+   * @brief Same pruning rule as {@code VisitWhileStmt}, for {@code do}/{@code while} loops.
+   *
+   * @param S The do statement being visited.
+   * @return {@code true} to continue traversal.
+   */
+  virtual bool VisitDoStmt(clang::DoStmt *S);
+
+  /**
+   * @brief Same pruning rule as {@code VisitWhileStmt}, for {@code for} loops.
+   *
+   * Additionally requires the init clause (a bare expression, or a
+   * declaration with a side-effect-free initializer) and the increment
+   * clause to be side-effect-free.
+   *
+   * @param S The for statement being visited.
+   * @return {@code true} to continue traversal.
+   */
+  virtual bool VisitForStmt(clang::ForStmt *S);
+
+  /**
+   * @brief Instructs the visitor to use post-order (depth-first) traversal.
    * @return {@code true} for post-order traversal.
    */
   bool shouldTraversePostOrder();
 
+  /**
+   * @brief Whether a statement performs no observable operation.
+   *
+   * True for {@code NullStmt}, and for any statement previously recorded in
+   * {@code _NoOpStmts} (dropped void calls, empty/all-no-op compound
+   * statements, erased if-statements). A null statement pointer (e.g. an
+   * absent {@code else} branch) counts as a no-op. Exposed so callers (e.g.
+   * {@code HavocCallsConsumer}) can check whether a whole function body
+   * collapsed to nothing once traversal is complete.
+   *
+   * @param S The statement to classify, or {@code nullptr}.
+   */
+  bool isNoOp(const clang::Stmt *S) const;
+
 private:
+  /**
+   * @brief Shared prune rule for if/while/do/for.
+   *
+   * If every statement in {@code branches} is a no-op and {@code cond},
+   * {@code init}, and {@code inc} are all side-effect-free (the latter two
+   * only meaningful for a for-loop and default to trivially-safe null), the
+   * whole statement {@code S} is erased from the source and marked a no-op.
+   *
+   * @param S        The statement to erase if it proves to be a no-op.
+   * @param keyLoc    The statement's leading keyword location, used for the
+   *                   main-file/macro guard (e.g. {@code getIfLoc()}).
+   * @param branches  Every branch/body statement that must be a no-op.
+   * @param cond      The controlling condition; must be side-effect-free.
+   * @param init      A for-loop's init clause, or {@code nullptr}.
+   * @param inc       A for-loop's increment clause, or {@code nullptr}.
+   * @return {@code true} if the statement was erased.
+   */
+  bool pruneIfNoOp(clang::Stmt *S, clang::SourceLocation keyLoc,
+                   std::initializer_list<const clang::Stmt *> branches, const clang::Expr *cond,
+                   const clang::Stmt *init = nullptr, const clang::Expr *inc = nullptr);
+
   clang::ASTContext *_C;
   std::shared_ptr<std::set<std::string>> _NeededSuffixes;
   clang::Rewriter &_Rewriter;
+  std::set<const clang::Stmt *> _NoOpStmts;
 };

--- a/src/transform/include/MainGenConsumer.hpp
+++ b/src/transform/include/MainGenConsumer.hpp
@@ -15,9 +15,10 @@
  * to {@code original_main}, then a fresh {@code int main(void)} is appended that
  * calls every function defined in the file with {@code __VERIFIER_nondet_*}
  * arguments. Functions with a parameter type that has no nondet equivalent
- * (pointers, structs, ...) and variadic functions are skipped. For
- * {@code original_main(int, char**)}, a synthesized {@code argc}/{@code argv}
- * harness is generated instead of skipping.
+ * (pointers, structs, ...), variadic functions, and functions whose body
+ * {@code HavocCallsConsumer} found to have collapsed entirely to no-ops are
+ * skipped. For {@code original_main(int, char**)}, a synthesized
+ * {@code argc}/{@code argv} harness is generated instead of skipping.
  */
 class MainGenConsumer : public clang::ASTConsumer {
 public:
@@ -26,9 +27,12 @@ public:
    *
    * @param neededSuffixes Verifier suffixes used by the harness, shared with
    *        {@code AddVerifiersConsumer} which emits the extern declarations.
+   * @param noOpFunctions  Names of functions {@code HavocCallsConsumer} found
+   *        to have an entirely no-op body; these are not harnessed.
    * @param rewriter       Shared rewriter for modifying the source buffer.
    */
-  MainGenConsumer(std::shared_ptr<std::set<std::string>> neededSuffixes, clang::Rewriter &rewriter);
+  MainGenConsumer(std::shared_ptr<std::set<std::string>> neededSuffixes,
+                  std::shared_ptr<std::set<std::string>> noOpFunctions, clang::Rewriter &rewriter);
 
   /**
    * @brief Renames an existing {@code main} and appends the generated harness main.
@@ -61,5 +65,6 @@ private:
   std::string genMainHarness(const clang::FunctionDecl *mainFn);
 
   std::shared_ptr<std::set<std::string>> _NeededSuffixes;
+  std::shared_ptr<std::set<std::string>> _NoOpFunctions;
   clang::Rewriter &_Rewriter;
 };


### PR DESCRIPTION
After code removal, e.g. a void function call. Enclosing blocks are checked, thanks to post-traversal order, for emptiness. This way and if/else and loop blocks without any code are properly removed. Control flow statements are checked for side effects and left if not side effect free so that, for example, a while loop (`while (x-- > 0)`), remains untouched even if its body is empty.