### PR TITLE
Fix/natsteven/3 bug fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,19 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install cmake ninja llvm@20 lld@20
 
+      - name: Put versioned clang on PATH (Ubuntu)
+        if: runner.os == 'Linux'
+        run: echo "/usr/lib/llvm-20/bin" >> "$GITHUB_PATH"
+
+      - name: Put versioned clang on PATH (macOS)
+        if: runner.os == 'macOS'
+        run: echo "$(brew --prefix llvm@20)/bin" >> "$GITHUB_PATH"
+
+      - name: Verify clang on PATH
+        run: |
+          command -v clang
+          clang --version
+
       - name: Configure (Ubuntu)
         if: runner.os == 'Linux'
         run: CXX=clang++-20 CC=clang-20 cmake -B build -S . -G Ninja -DLLVM_DIR="$(llvm-config-20 --cmakedir)"
@@ -42,3 +55,6 @@ jobs:
 
       - name: Test
         run: ctest --test-dir build --output-on-failure
+
+      - name: Smoke test (end-to-end filter/transform)
+        run: ./tests/smoke/run_smoke_test.sh ./build/filter ./build/transform

--- a/README.md
+++ b/README.md
@@ -52,6 +52,31 @@ When invoking CMake, point it at the versioned compiler:
 CXX=clang++-20 CC=clang-20 cmake -B build -S . -G Ninja
 ```
 
+## `clang` on `PATH` must match the build
+
+Beyond the build itself, `filter`/`transform` shell out to a bare `clang`
+command at runtime (see `ClangToolUtils.hpp` / `Transformer.cpp`) to
+preprocess and compile-check each candidate benchmark — this is separate
+from, and not guaranteed to match, the LLVM 20 libraries the tools are
+linked against. Neither platform puts the versioned LLVM install on `PATH`
+by default:
+
+- **Linux**: installing `clang-20` via apt does not repoint the unversioned
+  `clang` — that may already point at a different preinstalled version.
+  Put the versioned install first on `PATH`:
+  ```sh
+  export PATH="/usr/lib/llvm-20/bin:$PATH"
+  ```
+- **macOS**: Homebrew's `llvm@20` is keg-only, so it's never on `PATH`
+  automatically:
+  ```sh
+  export PATH="$(brew --prefix llvm@20)/bin:$PATH"
+  ```
+
+Run `clang --version` after exporting to confirm it resolves to LLVM 20
+before running `filter`/`transform` — a mismatched `clang` here can silently
+produce different benchmark output than the one the project was built and
+tested with. CI sets this explicitly for the same reason.
 
 # Build
 
@@ -149,4 +174,6 @@ Key sections:
 - `[Debugging Flags]` — `debug`, `debugLevel` (0–3)
 
 The transform stage preprocesses each surviving benchmark into a `.i` file with
-`gcc -E -P -std=gnu11`, requiring `gcc` on `PATH`.
+`clang -E -P -std=gnu11`, requiring `clang` on `PATH` (see
+["`clang` on `PATH` must match the build"](#clang-on-path-must-match-the-build)
+above).

--- a/src/common/include/ClangToolUtils.hpp
+++ b/src/common/include/ClangToolUtils.hpp
@@ -92,7 +92,11 @@ inline std::optional<std::string> getResourceDir() {
  * Returns owned {@code std::string} values rather than {@code const char*} so
  * the caller controls storage lifetime. Pass the result to
  * {@code CommonOptionsParser::create} via a {@code vector<const char*>} view.
- *
+ * The compile flags are placed after a literal {@code --}, which makes
+ * {@code CommonOptionsParser} build a {@code FixedCompilationDatabase}
+ * directly instead of searching {@code filePath}'s ancestor directories for a
+ * {@code compile_commands.json}.
+ * 
  * @param filePath    Path to the C source file to process.
  * @param resourceDir Value of {@code CLANG_RESOURCES} (from {@code getResourceDir}).
  * @return Argument vector suitable for passing to {@code CommonOptionsParser::create}.
@@ -101,16 +105,17 @@ inline std::vector<std::string> buildClangArgs(const std::string &filePath,
                                                const std::string &resourceDir) {
   std::vector<std::string> args = {
       "clang",
-      "-extra-arg=-xc",
-      "-extra-arg=-resource-dir=" + resourceDir,
-      "-extra-arg=-fparse-all-comments",
+      filePath,
+      "--",
+      "-xc",
+      "-resource-dir=" + resourceDir,
+      "-fparse-all-comments",
   };
   std::optional<std::string> sysroot = getSysroot();
   if (sysroot) {
-    args.push_back("-extra-arg=-isysroot");
-    args.push_back("-extra-arg=" + *sysroot);
+    args.push_back("-isysroot");
+    args.push_back(*sysroot);
   }
-  args.push_back(filePath);
   return args;
 }
 

--- a/src/common/include/StdHeaders.hpp
+++ b/src/common/include/StdHeaders.hpp
@@ -121,6 +121,9 @@ inline const std::unordered_map<std::string, StdHeaderInfo> kStdTypeHeaders = {
     {"pthread_key_t", {"pthread.h", HeaderCategory::Concurrency}},
     {"pthread_once_t", {"pthread.h", HeaderCategory::Concurrency}},
 
+    // <semaphore.h>
+    {"sem_t", {"semaphore.h", HeaderCategory::Concurrency}},
+
     // <stdarg.h>
     {"va_list", {"stdarg.h", HeaderCategory::Core}},
 

--- a/src/transform/TransformAction.cpp
+++ b/src/transform/TransformAction.cpp
@@ -16,9 +16,9 @@
 
 // Strip non-system includes: their functions are havocked by
 // HavocCallsConsumer, so the directives only leave unresolvable references
-// in the output. Unresolved includes also classify as C_User and get
-// dropped. Files that needed a local header's types or macros stop
-// compiling and are weeded out by keepCompilesOnly.
+// in the output. A quoted include is always project-local by convention and
+// gets stripped outright. Files that needed a local header's
+// types or macros stop compiling and are weeded out by keepCompilesOnly.
 void IncludeFinder::InclusionDirective(clang::SourceLocation HashLoc, const clang::Token &,
                                        llvm::StringRef FileName, bool IsAngled,
                                        clang::CharSourceRange FilenameRange,
@@ -27,12 +27,11 @@ void IncludeFinder::InclusionDirective(clang::SourceLocation HashLoc, const clan
                                        clang::SrcMgr::CharacteristicKind FileType) {
   if (!_Mgr.isInMainFile(HashLoc))
     return;
-  if (FileType == clang::SrcMgr::C_User) {
+  if (!IsAngled || FileType == clang::SrcMgr::C_User) {
     _Rewriter.RemoveText(clang::CharSourceRange::getCharRange(HashLoc, FilenameRange.getEnd()));
     return;
   }
-  if (IsAngled)
-    _ExistingIncludes->insert(FileName.str());
+  _ExistingIncludes->insert(FileName.str());
 }
 
 IncludeFinder::IncludeFinder(clang::SourceManager &SM, clang::Rewriter &rewriter,

--- a/tests/smoke/run_smoke_test.sh
+++ b/tests/smoke/run_smoke_test.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright (C) 2026 The ARG-V Project
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# End-to-end smoke test for the filter/transform pipeline, run against a
+# small fixed corpus (tests/smoke/samples) exercising known-quirky patterns.
+#
+# Unlike the ctest golden tests (which check AST-consumer behavior in
+# isolation), this drives the actual built binaries end-to-end, including
+# the `clang -E -P` / `clang -fsyntax-only` shell-outs in Transformer.cpp
+# that resolve `clang` via PATH rather than the linked LLVM libraries. That
+# path is the one most likely to drift between platforms (e.g. macOS
+# resolving Apple's system clang instead of Homebrew's llvm@20), so this is
+# meant to run on every CI platform, not just Linux.
+#
+# Usage: run_smoke_test.sh <filter_bin> <transform_bin>
+
+set -eu
+
+FILTER_BIN="${1:?usage: run_smoke_test.sh <filter_bin> <transform_bin>}"
+TRANSFORM_BIN="${2:?usage: run_smoke_test.sh <filter_bin> <transform_bin>}"
+SAMPLES_DIR="$(cd "$(dirname "$0")/samples" && pwd)"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+echo "=================================== Toolchain ==================================="
+echo "filter:    $FILTER_BIN"
+echo "transform: $TRANSFORM_BIN"
+echo "clang (PATH-resolved, used by Transformer.cpp's shell-outs):"
+command -v clang && clang --version || {
+  echo "FAIL: no 'clang' resolvable on PATH"
+  fail=1
+}
+
+echo
+echo "=================================== Run: default config (Concurrency=ignore) ==================================="
+cat > "$WORK/default.config" <<EOF
+[File Locations]
+filterDir=$WORK/filtered-default
+benchmarkDir=$WORK/bench-default
+EOF
+
+"$FILTER_BIN" "$SAMPLES_DIR" "$WORK/default.config"
+"$TRANSFORM_BIN" "$WORK/filtered-default" "$WORK/default.config"
+
+echo
+echo "--- Assertion: baseline file produces a benchmark ---"
+if [ ! -f "$WORK/bench-default/clean_ok.c" ]; then
+  echo "FAIL: clean_ok.c did not produce a benchmark — pipeline itself is broken on this platform"
+  fail=1
+else
+  echo "OK"
+fi
+
+echo
+echo "--- Assertion: no quoted #include survives in any produced benchmark ---"
+if ls "$WORK/bench-default"/*.c >/dev/null 2>&1 && grep -lE '^[[:space:]]*#include[[:space:]]*"' "$WORK/bench-default"/*.c; then
+  echo "FAIL: quoted include(s) leaked into benchmark output (files listed above)"
+  fail=1
+else
+  echo "OK"
+fi
+
+echo
+echo "=================================== Run: Concurrency=forbid ==================================="
+cat > "$WORK/forbid.config" <<EOF
+[File Locations]
+filterDir=$WORK/filtered-forbid
+benchmarkDir=$WORK/bench-forbid
+
+[Feature Requirements]
+Concurrency = forbid
+EOF
+
+"$FILTER_BIN" "$SAMPLES_DIR" "$WORK/forbid.config"
+"$TRANSFORM_BIN" "$WORK/filtered-forbid" "$WORK/forbid.config"
+
+echo
+echo "--- Assertion: no live pthread/semaphore call survives Concurrency=forbid ---"
+if ls "$WORK/bench-forbid"/*.i >/dev/null 2>&1 && \
+   grep -lE 'pthread_create\(|pthread_mutex_lock\(|pthread_mutex_unlock\(|pthread_join\(|sem_wait\(|sem_post\(' "$WORK/bench-forbid"/*.i; then
+  echo "FAIL: concurrency call(s) survived under Concurrency=forbid (files listed above)"
+  fail=1
+else
+  echo "OK"
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "=================================== SMOKE TEST FAILED ==================================="
+else
+  echo "=================================== SMOKE TEST PASSED ==================================="
+fi
+exit $fail

--- a/tests/smoke/samples/clean_ok.c
+++ b/tests/smoke/samples/clean_ok.c
@@ -1,0 +1,13 @@
+/* Baseline sanity file: no quirky constructs, should always survive the
+ * pipeline. If this ever stops producing a benchmark, the pipeline itself is
+ * broken (wrong clang, broken build, etc.) rather than anything quirk-specific. */
+#include <stdio.h>
+
+int compute(int a, int b) {
+  int total = 0;
+  for (int i = 0; i < b; i++) {
+    total += a;
+  }
+  printf("%d\n", total);
+  return total;
+}

--- a/tests/smoke/samples/pthread_sample.c
+++ b/tests/smoke/samples/pthread_sample.c
@@ -1,0 +1,20 @@
+/* Regression guard: under Concurrency=forbid, functions touching pthread_t/
+ * pthread_mutex_t must be stripped entirely, so no live pthread_* call
+ * should ever reach the final .i. */
+#include <pthread.h>
+#include <stdio.h>
+
+void *worker(void *arg) {
+  (void)arg;
+  return NULL;
+}
+
+int run_threads(void) {
+  pthread_t tid;
+  pthread_mutex_t lock;
+  pthread_mutex_lock(&lock);
+  pthread_create(&tid, NULL, worker, NULL);
+  pthread_join(tid, NULL);
+  pthread_mutex_unlock(&lock);
+  return 0;
+}

--- a/tests/smoke/samples/quoted_include.c
+++ b/tests/smoke/samples/quoted_include.c
@@ -1,0 +1,23 @@
+/* Regression guard for the quoted-include leak (see docs/... for the real
+ * incident: a vendored zlib.h, dropped by the filter step because it only
+ * ever copies .c files, silently got picked back up from the build host's
+ * /usr/include/zlib.h instead of the include directive being stripped).
+ *
+ * "stddef.h" here has no companion file anywhere near this source — it is
+ * deliberately quoted, not angled, to confirm it gets stripped purely
+ * because it's a quoted include, regardless of whether it happens to
+ * resolve. On every platform clang will still happily resolve it via its
+ * own bundled resource-dir headers (the same class of accidental fallback
+ * resolution that caused the zlib incident), which is exactly what makes
+ * this a faithful, portable reproduction: a naive "only strip if Clang
+ * couldn't resolve it" check passes this file too, since it does resolve —
+ * just to the wrong thing. The surviving code deliberately does not depend
+ * on anything stddef.h would provide, so the benchmark should still compile
+ * either way — the assertion in run_smoke_test.sh is purely textual,
+ * decoupled from whether this file happens to compile. */
+#include <stdio.h>
+#include "stddef.h"
+
+int identity(int x) {
+  return x;
+}

--- a/tests/smoke/samples/semaphore_sample.c
+++ b/tests/smoke/samples/semaphore_sample.c
@@ -1,0 +1,12 @@
+/* Regression guard for the sem_t gap in StdHeaders.hpp's concurrency
+ * registry: under Concurrency=forbid, sem_t-touching functions must be
+ * stripped just like pthread_t ones, so no live sem_wait/sem_post should
+ * ever reach the final .i. */
+#include <semaphore.h>
+
+int use_semaphore(void) {
+  sem_t sem;
+  sem_wait(&sem);
+  sem_post(&sem);
+  return 0;
+}


### PR DESCRIPTION
- clang would erroneously look for a `compile-commands.json` and if found potentially fail. 'Hard-coding' the options is more efficient anyways.
- Semaphores were not defined/included in `StdHeaders.hpp` so concurrency would get through.
- Header resolution could cause a system's locally installed library to allow non-standard definitions to get through
- Added CI and testing for these kinds of bugs and updated CI to properly force clang version during syntax check