### PR TITLE
Feature/#73/#75/natsteven/unreach and memsafety support

### DIFF
--- a/src/common/include/ConfigParser.hpp
+++ b/src/common/include/ConfigParser.hpp
@@ -39,6 +39,10 @@ struct PipelineConfig {
   std::map<std::string, FeatureGate> features = {
       {"Concurrency", FeatureGate::Ignore},
       {"FloatingPoint", FeatureGate::Ignore},
+      {"PointerOrArray", FeatureGate::Ignore},
+      {"PointerDeref", FeatureGate::Ignore},
+      {"MemAlloc", FeatureGate::Ignore},
+      {"MemFree", FeatureGate::Ignore},
   };
 
   /// File-level integer settings (booleans are stored as 0/1).

--- a/src/common/include/HavocPolicy.hpp
+++ b/src/common/include/HavocPolicy.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 The ARG-V Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * @file HavocPolicy.hpp
+ * @brief Bounds governing how much symbolic state generated havoc code creates.
+ *
+ * Every havocked object is finite. There bounds are emitted into generated
+ * benchmarks as @c __HAVOC_* macros so a benchmark can be retuned.
+ *
+ * Nondet values are constrained with @c if (cond) abort().
+ */
+
+/**
+ * @brief Lower bound on the synthesized @c argc.
+ *
+ * C11 5.1.2.2.1 permits @c argc==0 (with a NULL @c argv[0]), and Linux
+ * @c execve can produce it, but virtually every real @c main dereferences
+ * @c argv[0] unconditionally. Starting at 1 models normal execution instead of
+ * flagging every benchmark for a null deref; set to 0 to explore that path.
+ */
+inline constexpr unsigned kArgcMin = 1;
+
+/**
+ * @brief Upper bound on the synthesized @c argc.
+ *
+ * Each admitted argument costs a havocked string, so this multiplies with
+ * @ref kStrMax to set the harness's symbolic footprint.
+ */
+inline constexpr unsigned kArgcMax = 4;
+
+/**
+ * @brief Size in bytes of each havocked C string, terminator included.
+ *
+ * The terminator lands at a nondet offset in [0, kStrMax-1], so reachable
+ * string lengths span empty through @c kStrMax-1.
+ */
+inline constexpr unsigned kStrMax = 16;

--- a/src/common/include/StdHeaders.hpp
+++ b/src/common/include/StdHeaders.hpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 /**
  * @file StdHeaders.hpp
@@ -111,6 +112,11 @@ inline const std::unordered_map<std::string, std::string> StdHeaders = {
     {"feof", "stdio.h"},
     {"ferror", "stdio.h"},
     {"clearerr", "stdio.h"},
+    // POSIX/GNU extensions that allocate their own buffer (caller must free)
+    {"getline", "stdio.h"},
+    {"getdelim", "stdio.h"},
+    {"asprintf", "stdio.h"},
+    {"vasprintf", "stdio.h"},
 
     // <stdlib.h>
     // types
@@ -121,6 +127,9 @@ inline const std::unordered_map<std::string, std::string> StdHeaders = {
     {"malloc", "stdlib.h"},
     {"calloc", "stdlib.h"},
     {"realloc", "stdlib.h"},
+    {"reallocarray", "stdlib.h"},
+    {"aligned_alloc", "stdlib.h"},
+    {"posix_memalign", "stdlib.h"},
     {"free", "stdlib.h"},
     {"exit", "stdlib.h"},
     {"abort", "stdlib.h"},
@@ -176,6 +185,20 @@ inline const std::unordered_map<std::string, std::string> StdHeaders = {
     {"strlen", "string.h"},
     {"strdup", "string.h"},
     {"strndup", "string.h"},
+
+    // <wchar.h> (memory-alloc-relevant subset; the rest of wchar.h is out of
+    // scope for this registry until something else needs it)
+    {"wcsdup", "wchar.h"},
+
+    // glibc/BSD (declared in <malloc.h>, distinct from <stdlib.h>'s malloc family)
+    {"memalign", "malloc.h"},
+    {"valloc", "malloc.h"},
+    {"malloc_usable_size", "malloc.h"},
+
+    // <sys/mman.h>
+    {"mmap", "sys/mman.h"},
+    {"munmap", "sys/mman.h"},
+    {"mremap", "sys/mman.h"},
 
     // <ctype.h>
     // functions
@@ -431,5 +454,21 @@ inline const std::unordered_map<std::string, std::string> StdHeaders = {
     {"chmod", "sys/stat.h"}
 
     // assert.h handles by AssertRewriter in TransformAction
- 
+
 };
+
+/**
+ * @brief Named heap alloc/free functions relevant to memory-safety detection
+ */
+inline const std::unordered_set<std::string> MemoryFunctions = {
+    "malloc",  "calloc",         "realloc",  "reallocarray", "aligned_alloc",
+    "posix_memalign", "memalign", "valloc",  "free",
+    "strdup",  "strndup",        "wcsdup",
+    "mmap",    "munmap",         "mremap",
+    "getline", "getdelim",       "asprintf", "vasprintf",
+};
+
+/**
+ * @brief Returns true if `name` is one of the functions in `MemoryFunctions`.
+ */
+inline bool isMemoryFunction(const std::string &name) { return MemoryFunctions.count(name) > 0; }

--- a/src/common/include/StdHeaders.hpp
+++ b/src/common/include/StdHeaders.hpp
@@ -428,9 +428,8 @@ inline const std::unordered_map<std::string, std::string> StdHeaders = {
     {"fstat", "sys/stat.h"},
     {"lstat", "sys/stat.h"},
     {"mkdir", "sys/stat.h"},
-    {"chmod", "sys/stat.h"},
+    {"chmod", "sys/stat.h"}
 
-    // <assert.h>
-    // functions
-    {"assert", "assert.h"}
+    // assert.h handles by AssertRewriter in TransformAction
+ 
 };

--- a/src/common/include/VerifierNames.hpp
+++ b/src/common/include/VerifierNames.hpp
@@ -54,14 +54,14 @@ inline const std::unordered_map<std::string, std::string> kVerifierCTypes = {
 
 /**
  * @brief True for identifiers the pipeline itself injects (verifier nondet
- * externs/calls and the __havoc_* helpers).
+ * externs/calls, the __havoc_* helpers, and reach_error).
  *
  * The verify stage uses this to exempt generated artifacts from the metric
- * re-check: they are scaffolding, not program logic, and stripping e.g. a
- * __havoc_block definition would break the benchmark.
+ * re-check: they are scaffolding, not program logic.
  */
 inline bool isVerifierGenerated(const std::string &name) {
-  return name.rfind("__VERIFIER_", 0) == 0 || name.rfind("__havoc_", 0) == 0;
+  return name.rfind("__VERIFIER_", 0) == 0 || name.rfind("__havoc_", 0) == 0 ||
+         name == "reach_error";
 }
 
 /**

--- a/src/filter/CountingVisitor.cpp
+++ b/src/filter/CountingVisitor.cpp
@@ -25,7 +25,10 @@ std::string CountingVisitor::getDeclParentFuncName(const clang::Decl &D) {
   if (const clang::DeclContext *parentFuncContext = D.getParentFunctionOrMethod()) {
     if (parentFuncContext->isFunctionOrMethod()) {
       const clang::FunctionDecl *FD = clang::dyn_cast<clang::FunctionDecl>(parentFuncContext);
-      return FD->getNameAsString();
+      std::string name = FD->getNameAsString();
+      // guarantee function entry exists, may add harmless irrelevant entries
+      _allFunctions->try_emplace(name);
+      return name;
     }
   }
   return "FileScope";
@@ -38,8 +41,11 @@ std::string CountingVisitor::getStmtParentFuncName(const clang::Stmt &S) {
   if (parents.size()) {
     for (const clang::DynTypedNode &parent : parents) {
       // DynTypedNode is type-erased - try each possible parent kind
-      if (const clang::FunctionDecl *fd = parent.get<clang::FunctionDecl>())
-        return fd->getNameAsString();
+      if (const clang::FunctionDecl *fd = parent.get<clang::FunctionDecl>()) {
+        std::string name = fd->getNameAsString();
+        _allFunctions->try_emplace(name); // see getDeclParentFuncName
+        return name;
+      }
       if (const clang::Stmt *s = parent.get<clang::Stmt>())
         return getStmtParentFuncName(*s);
       if (const clang::Decl *d = parent.get<clang::Decl>())
@@ -50,14 +56,10 @@ std::string CountingVisitor::getStmtParentFuncName(const clang::Stmt &S) {
 }
 
 bool CountingVisitor::VisitCallExpr(clang::CallExpr *CE) {
-  // Only count direct CallExpr, not subclasses, to match the original
-  // getStmtClass()-based tally.
-  if (!_mgr->isInMainFile(CE->getBeginLoc()))
+  // Only count direct CallExpr, not subclasses
+  if (!_mgr->isInMainFile(_mgr->getExpansionLoc(CE->getBeginLoc())))
     return true;
-  // Verifier nondet / havoc-helper calls stand in for code the transform
-  // removed; they are not complexity of the function's own logic, so they
-  // never count toward CallFunc (matters when the verify stage re-counts a
-  // havocked file).
+  // don't count Verifier nondet / havoc-helper / reach_error / asserts
   if (const clang::FunctionDecl *callee = CE->getDirectCallee()) {
     if (callee->getIdentifier() && isVerifierGenerated(callee->getNameAsString()))
       return true;
@@ -76,27 +78,19 @@ bool CountingVisitor::VisitCallExpr(clang::CallExpr *CE) {
       break;
     }
   }
-  return true;
-}
-
-bool CountingVisitor::VisitVarDecl(clang::VarDecl *VD) {
-  if (_mgr->isInMainFile(VD->getLocation())) {
-    clang::QualType varType = VD->getType();
-    if (varType->isPointerType())
-      varType = varType->getPointeeType();
-    if (varType->isFloatingType())
-      _allFunctions->at(getDeclParentFuncName(*VD)).Features.FloatingPoint = true;
-    // check for concurrency
-    auto it = StdHeaders.find(varType.getUnqualifiedType().getAsString());
-    if (it != StdHeaders.end() &&
-        (it->second == "pthread.h" || it->second == "threads.h" || it->second == "semaphore.h"))
-      _allFunctions->at(getDeclParentFuncName(*VD)).Features.Concurrency = true;
+  if (const clang::FunctionDecl *callee = CE->getDirectCallee()) {
+    if (!callee->getIdentifier() || !_mgr->isInSystemHeader(callee->getBeginLoc())) return true;
+    if (callee->getNameAsString() == "free") {
+      _allFunctions->at(getStmtParentFuncName(*CE)).Features.MemFree = true;
+    } else if (isMemoryFunction(callee->getNameAsString())) {
+      _allFunctions->at(getStmtParentFuncName(*CE)).Features.MemAlloc = true;
+    }
   }
   return true;
 }
 
 bool CountingVisitor::VisitFunctionDecl(clang::FunctionDecl *FD) {
-  if (_mgr->isInMainFile(FD->getLocation())) {
+  if (_mgr->isInMainFile(_mgr->getExpansionLoc(FD->getLocation()))) {
     if (!_allFunctions->count(FD->getNameAsString()))
       _allFunctions->try_emplace(FD->getNameAsString());
     attributes &entry = _allFunctions->at(FD->getNameAsString());
@@ -108,26 +102,27 @@ bool CountingVisitor::VisitFunctionDecl(clang::FunctionDecl *FD) {
 }
 
 bool CountingVisitor::VisitIfStmt(clang::IfStmt *If) {
-  if (_mgr->isInMainFile(If->getIfLoc()))
+  if (_mgr->isInMainFile(_mgr->getExpansionLoc(If->getIfLoc())))
     _allFunctions->at(getStmtParentFuncName(*If)).Complexity.IfStmt++;
   return true;
 }
 
 bool CountingVisitor::VisitForStmt(clang::ForStmt *F) {
-  if (_mgr->isInMainFile(F->getForLoc()))
+  if (_mgr->isInMainFile(_mgr->getExpansionLoc(F->getForLoc())))
     _allFunctions->at(getStmtParentFuncName(*F)).Complexity.ForLoops++;
   return true;
 }
 
 bool CountingVisitor::VisitWhileStmt(clang::WhileStmt *W) {
-  if (_mgr->isInMainFile(W->getWhileLoc()))
+  if (_mgr->isInMainFile(_mgr->getExpansionLoc(W->getWhileLoc())))
     _allFunctions->at(getStmtParentFuncName(*W)).Complexity.WhileLoops++;
   return true;
 }
 
 bool CountingVisitor::VisitBinaryOperator(clang::BinaryOperator *B) {
   // Only signed overlfow is UB
-  if (_mgr->isInMainFile(B->getOperatorLoc()) && B->getType()->isSignedIntegerType()) {
+  if (_mgr->isInMainFile(_mgr->getExpansionLoc(B->getOperatorLoc())) &&
+      B->getType()->isSignedIntegerType()) {
     clang::BinaryOperator::Opcode op =
         B->isCompoundAssignmentOp()
             ? clang::BinaryOperator::getOpForCompoundAssignment(B->getOpcode())
@@ -140,9 +135,46 @@ bool CountingVisitor::VisitBinaryOperator(clang::BinaryOperator *B) {
 }
 
 bool CountingVisitor::VisitUnaryOperator(clang::UnaryOperator *U) {
-  if (_mgr->isInMainFile(U->getOperatorLoc()) && U->getType()->isSignedIntegerType()) {
-    if (U->canOverflow())
+  if (_mgr->isInMainFile(_mgr->getExpansionLoc(U->getOperatorLoc()))) {
+    if (U->canOverflow() && U->getType()->isSignedIntegerType())
       _allFunctions->at(getStmtParentFuncName(*U)).Complexity.Operations++;
+    if (U->getOpcode() == clang::UO_Deref)
+      _allFunctions->at(getStmtParentFuncName(*U)).Features.PointerDeref = true;
+  }
+  return true;
+}
+
+bool CountingVisitor::VisitArraySubscriptExpr(clang::ArraySubscriptExpr *ASE) {
+  if (_mgr->isInMainFile(_mgr->getExpansionLoc(ASE->getBeginLoc())))
+    _allFunctions->at(getStmtParentFuncName(*ASE)).Features.PointerDeref = true;
+  return true;
+}
+
+bool CountingVisitor::VisitMemberExpr(clang::MemberExpr *ME) {
+  if (_mgr->isInMainFile(_mgr->getExpansionLoc(ME->getExprLoc())) && ME->isArrow())
+    _allFunctions->at(getStmtParentFuncName(*ME)).Features.PointerDeref = true;
+  return true;
+}
+
+bool CountingVisitor::VisitStringLiteral(clang::StringLiteral *SL) {
+  if (_mgr->isInMainFile(_mgr->getExpansionLoc(SL->getBeginLoc())))
+    _allFunctions->at(getStmtParentFuncName(*SL)).Features.PointerOrArray = true;
+  return true;
+}
+
+bool CountingVisitor::VisitDeclRefExpr(clang::DeclRefExpr *DRE) {
+  if (_mgr->isInMainFile(_mgr->getExpansionLoc(DRE->getLocation()))) {
+    clang::QualType type = DRE->getType();
+    if (type->isPointerType() || type->isArrayType())
+      _allFunctions->at(getStmtParentFuncName(*DRE)).Features.PointerOrArray = true;
+    if (type->isPointerType())
+      type = type->getPointeeType();
+    if (type->isFloatingType())
+      _allFunctions->at(getStmtParentFuncName(*DRE)).Features.FloatingPoint = true;
+    auto it = StdHeaders.find(type.getUnqualifiedType().getAsString());
+    if (it != StdHeaders.end() &&
+        (it->second == "pthread.h" || it->second == "threads.h" || it->second == "semaphore.h"))
+      _allFunctions->at(getStmtParentFuncName(*DRE)).Features.Concurrency = true;
   }
   return true;
 }

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -20,14 +20,14 @@
 #include <llvm/Support/raw_ostream.h>
 #include <string>
 
-const std::string defaultFilterDir = "filteredFiles";
 const std::string defaultDatabaseDir = "repos";
 
 Filterer::Filterer(std::string configFile, std::string inputPath) {
-  configuration.filterDir = defaultFilterDir;
   configuration.databaseDir = defaultDatabaseDir;
   if (!configFile.empty())
     parseConfigFile(configFile);
+  if (configuration.filterDir.empty())
+    configuration.filterDir = inputBaseName(configuration.databaseDir) + "-filtered";
   if (!inputPath.empty()) {
     configuration.databaseDir = inputPath;
     configuration.filterDir = inputBaseName(inputPath) + "-filtered";

--- a/src/filter/include/CountingVisitor.hpp
+++ b/src/filter/include/CountingVisitor.hpp
@@ -46,6 +46,10 @@ public:
   struct FeatureFlags {
     bool Concurrency = false;
     bool FloatingPoint = false;
+    bool PointerOrArray = false; // coarse gate: pointer/array VarDecl|ParmVarDecl, string literal
+    bool PointerDeref = false;   // valid-deref signal: array subscript, *p, p->field
+    bool MemAlloc = false;       // valid-memtrack signal: malloc/calloc/realloc/strdup
+    bool MemFree = false;        // valid-free signal: free
   };
 
   /** @brief Per-function AST property counts, split across the two axes. */
@@ -86,13 +90,10 @@ public:
   std::string getDeclParentFuncName(const clang::Decl &D);
 
   /** @brief Counts function calls ({@code CallFunc}) and checks call
-   * arguments for characteristics (just concurrency for now), marking the
-   * enclosing function accordingly. */
+   * arguments/callee for characteristics (concurrency / memsafety), marking
+   * the enclosing function accordingly.
+  */
   bool VisitCallExpr(clang::CallExpr *CE);
-
-  /** @brief Counts variable declarations per function; flags floating-point
-   * and concurrency types. */
-  bool VisitVarDecl(clang::VarDecl *VD);
 
   /** @brief Registers each function in {@code _allFunctions}, increments the
    * file-level function count, and flags a floating-point return type. */
@@ -110,8 +111,22 @@ public:
   /** @brief Counts signed binary operations per function. */
   bool VisitBinaryOperator(clang::BinaryOperator *BO);
 
-  /** @brief Counts signed unary operations per function. */
+  /** @brief Counts signed unary operations per function and flags dereferences. */
   bool VisitUnaryOperator(clang::UnaryOperator *UO);
+
+  /** @brief flag FeatureFlags::PointerDeref on the enclosing function.
+   * `a[i]` is a dereference regardless of whether `a` is pointer- or array-typed. */
+  bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *ASE);
+
+  /** @brief flag FeatureFlags::PointerDeref on the enclosing function when {@code ME->isArrow()} */
+  bool VisitMemberExpr(clang::MemberExpr *ME);
+
+  /** @brief flag FeatureFlags::PointerOrArray on the enclosing function */
+  bool VisitStringLiteral(clang::StringLiteral *SL);
+
+  /** @brief flag PointerOrArray, FloatingPoint, and Concurrency on the
+   * enclosing function based on a referenced declaration's type. */
+  bool VisitDeclRefExpr(clang::DeclRefExpr *DRE);
 
 private:
   clang::ASTContext *_C;
@@ -122,8 +137,7 @@ private:
 /**
  * @brief Looks up a named field on the complexity axis, shared by the
  * filter's threshold check and the verify stage's post-transform re-check.
- * Throws if `name` isn't one of the known metrics; a config key typo should
- * surface loudly, not silently no-op.
+ * Throws if `name` isn't one of the known metrics.
  */
 inline int complexityField(const CountingVisitor::ComplexityCounts &c, const std::string &name) {
   if (name == "CallFunc")
@@ -143,12 +157,20 @@ inline int complexityField(const CountingVisitor::ComplexityCounts &c, const std
 
 /**
  * @brief Looks up a named flag on the feature axis. Throws if `name` isn't
- * one of the known features, for the same reason as complexityField above.
+ * one of the known features.
  */
 inline bool featureField(const CountingVisitor::FeatureFlags &f, const std::string &name) {
   if (name == "Concurrency")
     return f.Concurrency;
   if (name == "FloatingPoint")
     return f.FloatingPoint;
+  if (name == "PointerOrArray")
+    return f.PointerOrArray;
+  if (name == "PointerDeref")
+    return f.PointerDeref;
+  if (name == "MemAlloc")
+    return f.MemAlloc;
+  if (name == "MemFree")
+    return f.MemFree;
   throw std::invalid_argument("unknown feature: " + name);
 }

--- a/src/transform/AddVerifiersConsumer.cpp
+++ b/src/transform/AddVerifiersConsumer.cpp
@@ -4,6 +4,7 @@
 
 #include "AddVerifiersConsumer.hpp"
 
+#include "HavocPolicy.hpp"
 #include "VerifierNames.hpp"
 
 #include <clang/AST/ASTContext.h>
@@ -25,6 +26,7 @@ void AddVerifiersConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
 
   clang::SourceManager &mgr = Context.getSourceManager();
   clang::TranslationUnitDecl *TD = Context.getTranslationUnitDecl();
+
 
   // Insert before the first main-file decl, which keeps the externs below
   // the include block (includes are not decls). Fall back to the start of
@@ -52,6 +54,17 @@ void AddVerifiersConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
   }
 
   std::string decls;
+
+  // MainGenConsumer marks the argv harness with "__havoc_argv"; emit the
+  // bounds it references as macros so a user can retune a generated benchmark
+  // without rerunning the pipeline.
+  if (_NeededSuffixes->count("__havoc_argv")) {
+    decls += "#define __HAVOC_ARGC_MIN " + std::to_string(kArgcMin) + "\n" +
+             "#define __HAVOC_ARGC_MAX " + std::to_string(kArgcMax) + "\n" +
+             "#define __HAVOC_STR_MAX " + std::to_string(kStrMax) + "\n";
+  }
+
+  // emit verifier externs
   for (const std::string &suffix : *_NeededSuffixes) {
     std::optional<std::string> cType = cTypeForSuffix(suffix);
     if (!cType)
@@ -67,21 +80,26 @@ void AddVerifiersConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
   // helper names; emit the helper definitions they rely on. The helpers
   // hand out valid havocked blocks per the SV-COMP __VERIFIER_nondet_memory
   // contract (an arbitrary nondet pointer value must never be dereferenced).
+  // <stdlib.h> supplies malloc, abort and size_t
   bool needCString = _NeededSuffixes->count("__havoc_cstring");
   bool needBlock = needCString || _NeededSuffixes->count("__havoc_block");
   if (needBlock) {
-    decls += "extern void __VERIFIER_nondet_memory(void *, unsigned long);\n"
-             "extern void *malloc(unsigned long);\n"
-             "static void *__havoc_block(unsigned long size) {\n"
+    decls.insert(0, "#include <stdlib.h>\n");
+    if (needCString && !_NeededSuffixes->count("size_t"))
+      decls += "extern size_t __VERIFIER_nondet_size_t(void);\n";
+    decls += "extern void __VERIFIER_nondet_memory(void *, size_t);\n"
+             "static void *__havoc_block(size_t size) {\n"
              "  void *block = malloc(size);\n"
              "  __VERIFIER_nondet_memory(block, size);\n"
              "  return block;\n"
              "}\n";
   }
   if (needCString) {
-    decls += "static char *__havoc_cstring(unsigned long size) {\n"
+    decls += "static char *__havoc_cstring(size_t size) {\n"
              "  char *s = __havoc_block(size);\n"
-             "  s[size - 1] = '\\0';\n"
+             "  size_t len = __VERIFIER_nondet_size_t();\n"
+             "  if (len >= size) abort();\n"
+             "  s[len] = '\\0';\n"
              "  return s;\n"
              "}\n";
   }

--- a/src/transform/AddVerifiersConsumer.cpp
+++ b/src/transform/AddVerifiersConsumer.cpp
@@ -86,6 +86,12 @@ void AddVerifiersConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
              "}\n";
   }
 
+  // AssertRewriter rewrote at least one assert(cond) to reach_error()
+  if (_NeededSuffixes->count("__reach_error")) {
+    decls += "#include <assert.h>\n"
+             "void reach_error(void) { assert(0); }\n";
+  }
+
   if (!decls.empty())
     _Rewriter.InsertTextBefore(loc, decls + "\n");
 }

--- a/src/transform/MainGenConsumer.cpp
+++ b/src/transform/MainGenConsumer.cpp
@@ -95,18 +95,20 @@ std::string MainGenConsumer::genMainHarness(const clang::FunctionDecl *mainFn) {
 
   // int main(int argc, char **argv[, char **envp]): build a nondet argc and
   // an argv of havocked C strings, then call original_main(argc, argv).
+  // The bounds are __HAVOC_* macros emitted by AddVerifiersConsumer, so the
+  // generated benchmark stays retunable by hand.
 
   std::string body;
-  body += "  extern void abort(void);\n";
   body += "  int argc = __VERIFIER_nondet_int();\n";
-  body += "  if (argc < 0 || argc > 7) abort();\n";
-  body += "  char *argv[argc + 1];\n";
+  body += "  if (argc < __HAVOC_ARGC_MIN || argc > __HAVOC_ARGC_MAX) abort();\n";
+  body += "  char *argv[__HAVOC_ARGC_MAX + 1];\n";
   body += "  for (int i = 0; i < argc; i++)\n";
-  body += "    argv[i] = __havoc_cstring(16);\n";
+  body += "    argv[i] = __havoc_cstring(__HAVOC_STR_MAX);\n";
   body += "  argv[argc] = 0;\n";
   body += "  original_main(argc, argv);\n";
 
   _NeededSuffixes->insert("int");
   _NeededSuffixes->insert("__havoc_cstring");
+  _NeededSuffixes->insert("__havoc_argv");
   return body;
 }

--- a/src/transform/TransformAction.cpp
+++ b/src/transform/TransformAction.cpp
@@ -11,6 +11,8 @@
 
 #include <clang/Basic/SourceManager.h>
 #include <clang/Frontend/MultiplexConsumer.h>
+#include <clang/Lex/Lexer.h>
+#include <clang/Lex/MacroArgs.h>
 #include <clang/Lex/Preprocessor.h>
 #include <memory>
 #include <vector>
@@ -37,20 +39,59 @@ IncludeFinder::IncludeFinder(clang::SourceManager &SM, clang::Rewriter &rewriter
                              std::shared_ptr<std::set<std::string>> existingIncludes)
     : _Mgr(SM), _Rewriter(rewriter), _ExistingIncludes(existingIncludes) {}
 
+// assert(cond) always expands with the macro name token first and the
+// closing paren as the invocation's last token, so Range brackets exactly
+// the text to replace
+void AssertRewriter::MacroExpands(const clang::Token &MacroNameTok, const clang::MacroDefinition &MD,
+                                  clang::SourceRange Range, const clang::MacroArgs *) {
+  const clang::IdentifierInfo *id = MacroNameTok.getIdentifierInfo();
+  if (!id || id->getName() != "assert")
+    return;
+  const clang::MacroInfo *info = MD.getMacroInfo();
+  if (!info || !info->isFunctionLike())
+    return;
+  if (!Range.getBegin().isFileID() || !_Mgr.isInMainFile(Range.getBegin()))
+    return;
+
+  clang::CharSourceRange charRange = clang::CharSourceRange::getTokenRange(Range);
+  bool invalid = false;
+  llvm::StringRef text = clang::Lexer::getSourceText(charRange, _Mgr, _LangOpts, &invalid);
+  if (invalid)
+    return;
+
+  size_t openParen = text.find('(');
+  size_t closeParen = text.rfind(')');
+  if (openParen == llvm::StringRef::npos || closeParen == llvm::StringRef::npos ||
+      closeParen <= openParen)
+    return;
+  llvm::StringRef cond = text.substr(openParen + 1, closeParen - openParen - 1);
+
+  debugLog(3, "[transform] rewrote assert(" + cond.str() + ") -> reach_error()");
+  _Rewriter.ReplaceText(charRange, ("if (!(" + cond + ")) reach_error()").str());
+  _NeededSuffixes->insert("__reach_error");
+}
+
+AssertRewriter::AssertRewriter(clang::SourceManager &SM, clang::Rewriter &rewriter,
+                               std::shared_ptr<std::set<std::string>> neededSuffixes,
+                               const clang::LangOptions &langOpts)
+    : _Mgr(SM), _Rewriter(rewriter), _NeededSuffixes(neededSuffixes), _LangOpts(langOpts) {}
+
 TransformAction::TransformAction(llvm::raw_ostream &output) : _Output(output), _Rewriter() {}
 
 // unique_ptr can't be copied, so tempVector is built up and moved into MultiplexConsumer.
 std::unique_ptr<clang::ASTConsumer>
 TransformAction::CreateASTConsumer(clang::CompilerInstance &compiler, llvm::StringRef) {
   auto existingIncludes = std::make_shared<std::set<std::string>>();
+  // Verifier suffixes needed by call havocking and the generated main;
+  // AddVerifiersConsumer runs last and emits the extern declarations
+  auto neededSuffixes = std::make_shared<std::set<std::string>>();
 
   clang::Preprocessor &pp = compiler.getPreprocessor();
   pp.addPPCallbacks(
       std::make_unique<IncludeFinder>(compiler.getSourceManager(), _Rewriter, existingIncludes));
+  pp.addPPCallbacks(std::make_unique<AssertRewriter>(compiler.getSourceManager(), _Rewriter,
+                                                     neededSuffixes, pp.getLangOpts()));
 
-  // Verifier suffixes needed by call havocking and the generated main;
-  // AddVerifiersConsumer runs last and emits the extern declarations
-  auto neededSuffixes = std::make_shared<std::set<std::string>>();
   // Functions HavocCallsConsumer found to have collapsed entirely to no-ops;
   // MainGenConsumer skips harnessing them
   auto noOpFunctions = std::make_shared<std::set<std::string>>();

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -20,18 +20,20 @@
 #include <unistd.h>
 
 const int defaultDebugLevel = 0;
-const std::string defaultFilterDir = "filteredFiles";
-const std::string defaultTransformDir = "transformedFiles";
+// Mirrors Filterer's own fallback default ("repos" -> "repos-filtered"), so a
+// bare Transformer invocation lines up with a bare Filterer invocation.
+const std::string defaultFilterDir = "repos-filtered";
 /// Per-file wall-clock budget for the isolated transform child, in seconds.
 const int defaultFileTimeoutSecs = 60;
 
 Transformer::Transformer(std::string configFile, std::string inputPath) : configuration() {
   configuration.debugLevel = defaultDebugLevel;
   configuration.filterDir = defaultFilterDir;
-  configuration.transformDir = defaultTransformDir;
   configuration.fileTimeoutSecs = defaultFileTimeoutSecs;
   if (!configFile.empty())
     parseConfig(configFile);
+  if (configuration.transformDir.empty())
+    configuration.transformDir = inputBaseName(configuration.filterDir) + "-transformed";
   if (!inputPath.empty()) {
     configuration.filterDir = inputPath;
     configuration.transformDir = inputBaseName(inputPath) + "-transformed";

--- a/src/transform/include/AddVerifiersConsumer.hpp
+++ b/src/transform/include/AddVerifiersConsumer.hpp
@@ -18,9 +18,10 @@
  * by earlier consumers (havoc calls, main generation), inserts an
  * {@code extern <type> __VERIFIER_nondet_<suffix>(void);} declaration. Also emits
  * helper definitions for {@code __havoc_block} and {@code __havoc_cstring} when
- * those markers are present in the suffix set, and a {@code reach_error()}
- * definition (plus its own {@code #include <assert.h>}) when {@code AssertRewriter}
- * recorded the "__reach_error" marker.
+ * those markers are present in the suffix set, the {@code __HAVOC_*} bound
+ * macros when {@code MainGenConsumer} recorded the "__havoc_argv" marker, and a
+ * {@code reach_error()} definition (plus its own {@code #include <assert.h>})
+ * when {@code AssertRewriter} recorded the "__reach_error" marker.
  */
 class AddVerifiersConsumer : public clang::ASTConsumer {
 public:

--- a/src/transform/include/AddVerifiersConsumer.hpp
+++ b/src/transform/include/AddVerifiersConsumer.hpp
@@ -16,10 +16,11 @@
  *
  * Runs last in the transform consumer chain. For every verifier suffix recorded
  * by earlier consumers (havoc calls, main generation), inserts an
- * {@code extern <type> __VERIFIER_nondet_<suffix>(void);} declaration at the top
- * of the main file, skipping any that the filter step already injected. Also emits
+ * {@code extern <type> __VERIFIER_nondet_<suffix>(void);} declaration. Also emits
  * helper definitions for {@code __havoc_block} and {@code __havoc_cstring} when
- * those markers are present in the suffix set.
+ * those markers are present in the suffix set, and a {@code reach_error()}
+ * definition (plus its own {@code #include <assert.h>}) when {@code AssertRewriter}
+ * recorded the "__reach_error" marker.
  */
 class AddVerifiersConsumer : public clang::ASTConsumer {
 public:
@@ -27,7 +28,7 @@ public:
    * @brief Constructs the consumer with the shared pipeline state.
    *
    * @param neededSuffixes Verifier suffixes collected by earlier consumers
-   *        ({@code HavocCallsConsumer}, {@code MainGenConsumer}).
+   *        ({@code HavocCallsConsumer}, {@code MainGenConsumer}, {@code AssertRewriter}).
    * @param rewriter       Shared rewriter for modifying the source buffer.
    */
   AddVerifiersConsumer(std::shared_ptr<std::set<std::string>> neededSuffixes,

--- a/src/transform/include/MainGenConsumer.hpp
+++ b/src/transform/include/MainGenConsumer.hpp
@@ -57,9 +57,12 @@ private:
    *
    * Unlike an arbitrary function, {@code main}'s pointer params have a known
    * contract, so instead of skipping it we synthesize a realistic call: a nondet
-   * {@code argc} bounded to [0, 7] via {@code abort()}, and an {@code argv}
-   * array of havocked, null-terminated C strings (via {@code __havoc_cstring}).
-   * Registers any verifier helpers it uses in {@code _NeededSuffixes}.
+   * {@code argc} bounded to [{@code __HAVOC_ARGC_MIN}, {@code __HAVOC_ARGC_MAX}]
+   * via {@code abort()}, and a fixed-extent {@code argv} array of havocked,
+   * null-terminated C strings (via {@code __havoc_cstring}). The bounds come
+   * from {@code HavocPolicy.hpp} and are emitted as macros by
+   * {@code AddVerifiersConsumer}. Registers any verifier helpers it uses in
+   * {@code _NeededSuffixes}.
    *
    * @param mainFn The original {@code main} FunctionDecl (already renamed in
    *               the rewriter output).

--- a/src/transform/include/TransformAction.hpp
+++ b/src/transform/include/TransformAction.hpp
@@ -5,9 +5,11 @@
 #pragma once
 
 #include <clang/AST/ASTConsumer.h>
+#include <clang/Basic/LangOptions.h>
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendAction.h>
+#include <clang/Lex/MacroInfo.h>
 #include <clang/Lex/PPCallbacks.h>
 #include <clang/Lex/Token.h>
 #include <clang/Rewrite/Core/Rewriter.h>
@@ -17,49 +19,6 @@
 #include <memory>
 #include <set>
 #include <string>
-
-/**
- * @brief PPCallbacks hook that strips non-system #include directives.
- *
- * System headers (C stdlib and platform headers) are kept; project-local
- * includes are removed from the output, since every function they declare is
- * havocked by HavocCallsConsumer anyway. A file that uses types or macros
- * from a local header will no longer compile after stripping; those outputs
- * are weeded out by keepCompilesOnly (header type/macro handling is a future
- * feature).
- */
-class IncludeFinder : public clang::PPCallbacks {
-public:
-  /**
-   * @brief Constructs the callback, binding the source manager and rewriter.
-   *
-   * @param SM       Source manager, used to check whether directives are in the main file.
-   * @param rewriter Shared rewriter the include directives are removed through.
-   */
-  IncludeFinder(clang::SourceManager &SM, clang::Rewriter &rewriter,
-                std::shared_ptr<std::set<std::string>> existingIncludes);
-
-  /**
-   * @brief Called by the preprocessor for each #include/#import directive.
-   *
-   * @param HashLoc       Location of the '#' that begins the directive.
-   * @param FileName      Name of the included file as written in the source.
-   * @param IsAngled      True for <...> includes, false for "..." includes.
-   * @param FilenameRange Source range of the filename text.
-   * @param FileType      Characteristic kind (system/user) of the included file.
-   */
-  void InclusionDirective(clang::SourceLocation HashLoc, const clang::Token &IncludeTok,
-                          llvm::StringRef FileName, bool IsAngled,
-                          clang::CharSourceRange FilenameRange, clang::OptionalFileEntryRef File,
-                          llvm::StringRef SearchPath, llvm::StringRef RelativePath,
-                          const clang::Module *SuggestedModule, bool ModuleImported,
-                          clang::SrcMgr::CharacteristicKind FileType) override;
-
-private:
-  clang::SourceManager &_Mgr;
-  clang::Rewriter &_Rewriter;
-  std::shared_ptr<std::set<std::string>> _ExistingIncludes;
-};
 
 /**
  * @brief ASTFrontendAction that drives the transform consumer pipeline.
@@ -139,3 +98,89 @@ public:
 private:
   llvm::raw_ostream &_Output;
 };
+
+/**
+ * @brief PPCallbacks hook that strips non-system #include directives.
+ *
+ * System headers (C stdlib and platform headers) are kept; project-local
+ * includes are removed from the output, since every function they declare is
+ * havocked by HavocCallsConsumer anyway. A file that uses types or macros
+ * from a local header will no longer compile after stripping; those outputs
+ * are weeded out by keepCompilesOnly (header type/macro handling is a future
+ * feature).
+ */
+class IncludeFinder : public clang::PPCallbacks {
+public:
+  /**
+   * @brief Constructs the callback, binding the source manager and rewriter.
+   *
+   * @param SM       Source manager, used to check whether directives are in the main file.
+   * @param rewriter Shared rewriter the include directives are removed through.
+   */
+  IncludeFinder(clang::SourceManager &SM, clang::Rewriter &rewriter,
+                std::shared_ptr<std::set<std::string>> existingIncludes);
+
+  /**
+   * @brief Called by the preprocessor for each #include/#import directive.
+   *
+   * @param HashLoc       Location of the '#' that begins the directive.
+   * @param FileName      Name of the included file as written in the source.
+   * @param IsAngled      True for <...> includes, false for "..." includes.
+   * @param FilenameRange Source range of the filename text.
+   * @param FileType      Characteristic kind (system/user) of the included file.
+   */
+  void InclusionDirective(clang::SourceLocation HashLoc, const clang::Token &IncludeTok,
+                          llvm::StringRef FileName, bool IsAngled,
+                          clang::CharSourceRange FilenameRange, clang::OptionalFileEntryRef File,
+                          llvm::StringRef SearchPath, llvm::StringRef RelativePath,
+                          const clang::Module *SuggestedModule, bool ModuleImported,
+                          clang::SrcMgr::CharacteristicKind FileType) override;
+
+private:
+  clang::SourceManager &_Mgr;
+  clang::Rewriter &_Rewriter;
+  std::shared_ptr<std::set<std::string>> _ExistingIncludes;
+};
+
+/**
+ * @brief PPCallbacks hook that rewrites {@code assert(cond)} invocations.
+ *
+ * SV-Comp's unreach-call property is checked against calls to a
+ * function literally named {@code reach_error}, so `assert(cond)` becomes
+ * {@code if (!(cond)) reach_error()}
+ */
+class AssertRewriter : public clang::PPCallbacks {
+public:
+  /**
+   * @brief Constructs the callback, binding the source manager and rewriter.
+   *
+   * @param SM             Source manager, used to check whether the invocation is in the main file.
+   * @param rewriter       Shared rewriter the invocation is rewritten through.
+   * @param neededSuffixes Output set; "__reach_error" is inserted when a rewrite happens, so
+   *                       AddVerifiersConsumer knows to emit the reach_error() definition.
+   * @param langOpts       Language options, needed to re-lex the invocation's source text.
+   */
+  AssertRewriter(clang::SourceManager &SM, clang::Rewriter &rewriter,
+                 std::shared_ptr<std::set<std::string>> neededSuffixes,
+                 const clang::LangOptions &langOpts);
+
+  /**
+   * @brief Called by the preprocessor for each macro expansion.
+   *
+   * Rewrites the invocation in place when the expanded macro is
+   * `assert`, invoked directly in the main file.
+   *
+   * @param MacroNameTok The macro name token (`assert`).
+   * @param MD           The macro's definition.
+   * @param Range        Source range spanning the whole invocation, name to closing paren.
+   */
+  void MacroExpands(const clang::Token &MacroNameTok, const clang::MacroDefinition &MD,
+                    clang::SourceRange Range, const clang::MacroArgs *Args) override;
+
+private:
+  clang::SourceManager &_Mgr;
+  clang::Rewriter &_Rewriter;
+  std::shared_ptr<std::set<std::string>> _NeededSuffixes;
+  const clang::LangOptions &_LangOpts;
+};
+

--- a/src/verify/Verifier.cpp
+++ b/src/verify/Verifier.cpp
@@ -150,7 +150,6 @@ void __VERIFIER_nondet_memory(void *mem, size_t size) {
   unsigned char *p = (unsigned char *)mem;
   for (size_t i = 0; i < size; i++) p[i] = __VERIFIER_nondet_uchar();
 }
-void reach_error(void) {}
 )";
 
 // NOTE: cmd is passed to std::system (shell-interpreted), and path/verifierPath
@@ -176,6 +175,8 @@ bool Verifier::checkCompilable(std::filesystem::path path) {
 std::vector<BenchmarkProperty> Verifier::selectProperties(
     const std::unordered_map<std::string, CountingVisitor::attributes> &counts) {
   std::vector<BenchmarkProperty> properties;
+  if (counts.count("reach_error"))
+    properties.push_back({"../properties/unreach-call.prp", true});
   bool loopsPresent = false;
   bool intArithPresent = false;
   for (const auto &[name, attr] : counts) {
@@ -222,6 +223,8 @@ void Verifier::writeBenchmarkTask(
       << "options:\n"
       << "  language: C\n"
       << "  data_model: LP64\n";
+  if (properties.empty())
+    debugLog(1, "[verify] WARN: no properties found for " + cPath.string());
 }
 
 // NOTE: same std::system/unescaped-path caveat as checkCompilable above.

--- a/src/verify/Verifier.cpp
+++ b/src/verify/Verifier.cpp
@@ -20,8 +20,9 @@
 #include <string>
 #include <system_error>
 
-const std::string defaultTransformDir = "transformedFiles";
-const std::string defaultBenchmarkDir = "benchmarks";
+// Mirrors Transformer's own fallback default, so a bare Verifier invocation
+// lines up with the rest of the "repos" -> "repos-benchmarks" chain.
+const std::string defaultTransformDir = "repos-transformed";
 
 Verifier::Verifier(std::string configFile, std::string inputPath) : configuration() {
   config = parsePipelineConfig(configFile);
@@ -29,13 +30,11 @@ Verifier::Verifier(std::string configFile, std::string inputPath) : configuratio
   configuration.keepCompilesOnly = config.fileSettings.at("keepCompilesOnly") != 0;
   configuration.transformDir =
       config.transformDir.empty() ? defaultTransformDir : config.transformDir;
-  configuration.benchmarkDir =
-      config.benchmarkDir.empty() ? defaultBenchmarkDir : config.benchmarkDir;
-  if (!inputPath.empty()) {
+  if (!inputPath.empty())
     configuration.transformDir = inputPath;
-    if (inputBaseName(inputPath) != defaultTransformDir)
-      configuration.benchmarkDir = inputBaseName(inputPath) + "-benchmarks";
-  }
+  configuration.benchmarkDir = config.benchmarkDir.empty()
+                                    ? inputBaseName(configuration.transformDir) + "-benchmarks"
+                                    : config.benchmarkDir;
   globalDebugLevel() = configuration.debugLevel;
 }
 

--- a/src/verify/Verifier.cpp
+++ b/src/verify/Verifier.cpp
@@ -178,6 +178,7 @@ std::vector<BenchmarkProperty> Verifier::selectProperties(
     properties.push_back({"../properties/unreach-call.prp", true});
   bool loopsPresent = false;
   bool intArithPresent = false;
+  bool memsafetyPresent = false;
   for (const auto &[name, attr] : counts) {
     if (!loopsPresent && (attr.Complexity.ForLoops || attr.Complexity.WhileLoops)) {
       loopsPresent = true;
@@ -188,7 +189,13 @@ std::vector<BenchmarkProperty> Verifier::selectProperties(
       intArithPresent = true;
       properties.push_back({"../properties/no-overflow.prp", true});
     }
-    if (loopsPresent && intArithPresent)
+    // valid-memsafety.prp bundles deref/free/memtrack CHECKs in one file
+    if (!memsafetyPresent &&
+        (attr.Features.PointerDeref || attr.Features.MemAlloc || attr.Features.MemFree)) {
+      memsafetyPresent = true;
+      properties.push_back({"../properties/valid-memsafety.prp", true});
+    }
+    if (loopsPresent && intArithPresent && memsafetyPresent)
       break;
   }
   return properties;

--- a/tests/filter/CountingVisitorTest.cpp
+++ b/tests/filter/CountingVisitorTest.cpp
@@ -246,7 +246,7 @@ const char *kPthreadStubs = R"(
 
 TEST(CountingVisitor, ConcurrencyFlaggedForLocalPthreadVariable) {
   // A pthread_mutex_t declared and locked entirely inside the function should
-  // flag it via the VisitVarDecl path.
+  // flag it via the VisitDeclRefExpr path (the `&m` references in each call).
   auto r = runCounter(std::string(kPthreadStubs) + R"(
     void worker() {
       pthread_mutex_t m;
@@ -259,9 +259,12 @@ TEST(CountingVisitor, ConcurrencyFlaggedForLocalPthreadVariable) {
 }
 
 TEST(CountingVisitor, ConcurrencyFlaggedByCallArgumentAlone) {
-  // The pthread_mutex_t lives at file scope ("Program"), never as a VarDecl
-  // inside the function; only the call argument's type can catch this, so
-  // this isolates the VisitCallExpr path from the VisitVarDecl path.
+  // The pthread_mutex_t lives at file scope ("Program"), so referencing it as
+  // a call argument (`&global_lock`) is now caught twice over: once by
+  // VisitCallExpr's own argument-type check, and independently by
+  // VisitDeclRefExpr on the `global_lock` reference itself. Kept as a
+  // regression check that the call-argument path still works even though
+  // it's no longer the only path that would catch this case.
   auto r = runCounter(std::string(kPthreadStubs) + R"(
     pthread_mutex_t global_lock;
     void worker() {
@@ -274,7 +277,8 @@ TEST(CountingVisitor, ConcurrencyFlaggedByCallArgumentAlone) {
 
 TEST(CountingVisitor, ConcurrencyFlaggedForPointerTypedLocal) {
   // A pointer-typed local (pthread_mutex_t *) with no call at all should
-  // still be flagged; VisitVarDecl strips the pointer before the lookup.
+  // still be flagged; VisitDeclRefExpr strips one level of pointer before the
+  // lookup, matched on the `m` reference in `alias`'s initializer.
   auto r = runCounter(std::string(kPthreadStubs) + R"(
     void worker(pthread_mutex_t *m) {
       pthread_mutex_t *alias = m;
@@ -316,15 +320,27 @@ TEST(CountingVisitor, ConcurrencyIsolatedPerFunction) {
 // ---------------------------------------------------------------------------
 
 TEST(CountingVisitor, FloatingPointFlaggedForLocalFloatVariable) {
-  auto r = runCounter("void foo() { float x = 1.0f; }");
+  // Detection is usage-based, not declaration-based (see
+  // FloatingPointNotSetForUnusedFloatVariable below) - the variable must
+  // actually be referenced somewhere for its type to count.
+  auto r = runCounter("void foo() { float x = 1.0f; (void)x; }");
   ASSERT_TRUE(r.funcs->count("foo"));
   EXPECT_TRUE(r.funcs->at("foo").Features.FloatingPoint);
 }
 
 TEST(CountingVisitor, FloatingPointFlaggedForDoubleParam) {
-  auto r = runCounter("void foo(double x) {}");
+  auto r = runCounter("void foo(double x) { (void)x; }");
   ASSERT_TRUE(r.funcs->count("foo"));
   EXPECT_TRUE(r.funcs->at("foo").Features.FloatingPoint);
+}
+
+TEST(CountingVisitor, FloatingPointNotSetForUnusedFloatVariable) {
+  // A declared-but-never-referenced pointer/float/concurrency-typed variable
+  // flags nothing: nothing in the function actually does anything with it,
+  // so there's no real floating-point/pointer/concurrency behavior to report.
+  auto r = runCounter("void foo() { float x = 1.0f; }");
+  ASSERT_TRUE(r.funcs->count("foo"));
+  EXPECT_FALSE(r.funcs->at("foo").Features.FloatingPoint);
 }
 
 TEST(CountingVisitor, FloatingPointFlaggedForFloatReturnType) {
@@ -341,7 +357,7 @@ TEST(CountingVisitor, FloatingPointNotSetForIntOnlyFunction) {
 
 TEST(CountingVisitor, FloatingPointIsolatedPerFunction) {
   auto r = runCounter(R"(
-    void withFloat() { float x = 1.0f; }
+    void withFloat() { float x = 1.0f; (void)x; }
     int clean(int x) { return x + 1; }
   )");
   ASSERT_TRUE(r.funcs->count("withFloat"));

--- a/tests/filter/FiltererStageTest.cpp
+++ b/tests/filter/FiltererStageTest.cpp
@@ -137,6 +137,33 @@ TEST_F(FiltererStageTest, AcceptsNonStdHeader) {
   EXPECT_TRUE(fs::exists(filterDir / "uses_local.c"));
 }
 
+TEST_F(FiltererStageTest, HeaderSplicedSignatureDoesNotCrash) {
+  // A function whose signature is spliced in from an #include'd header but
+  // whose body is written directly in the main file (legal, if unusual, C -
+  // the parser doesn't care about file boundaries mid-declaration).
+  // FunctionDecl::getLocation() (the name token) resolves into the header, so
+  // it's never registered in _allFunctions - but the body's statements are
+  // genuinely in the main file, so CountingVisitor's per-node gates still let
+  // them through, and getStmtParentFuncName's structural parent-walk still
+  // (correctly) resolves them to "foo". Before CountingVisitor guaranteed the
+  // resolved name always has a map entry, this crashed with
+  // unordered_map::at and silently dropped the whole file from the run.
+  writeConfig();
+  writeFile(databaseDir / "signature.h", "void foo(void)\n");
+  writeFile(databaseDir / "spliced.c", "#include \"signature.h\"\n"
+                                        "{\n"
+                                        "  int *p = 0;\n"
+                                        "  (void)p;\n"
+                                        "}\n"
+                                        "\n"
+                                        "int main(void) { foo(); return 0; }\n");
+
+  Filterer f(configPath.string());
+  f.run();
+
+  EXPECT_TRUE(fs::exists(filterDir / "spliced.c"));
+}
+
 TEST_F(FiltererStageTest, StripsFunctionFailingComplexityThreshold) {
   // ForLoops = 1,9999 requires at least one for loop per function: `plain`
   // fails and is stripped to a bare declaration; `loopy` keeps its body.

--- a/tests/transform/cases/assert-rewrite.expected.c
+++ b/tests/transform/cases/assert-rewrite.expected.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+extern int __VERIFIER_nondet_int(void);
+#include <assert.h>
+void reach_error(void) { assert(0); }
+
+int add(int a, int b) {
+  int r = a + b;
+  if (!(r >= a)) reach_error();
+  return r;
+}
+
+int main(void) {
+  add(__VERIFIER_nondet_int(), __VERIFIER_nondet_int());
+  return 0;
+}

--- a/tests/transform/cases/assert-rewrite.input.c
+++ b/tests/transform/cases/assert-rewrite.input.c
@@ -1,0 +1,6 @@
+#include <assert.h>
+int add(int a, int b) {
+  int r = a + b;
+  assert(r >= a);
+  return r;
+}

--- a/tests/transform/cases/havoc-by-return-type.expected.c
+++ b/tests/transform/cases/havoc-by-return-type.expected.c
@@ -1,15 +1,18 @@
+#include <stdlib.h>
 extern float __VERIFIER_nondet_float(void);
 extern int __VERIFIER_nondet_int(void);
-extern void __VERIFIER_nondet_memory(void *, unsigned long);
-extern void *malloc(unsigned long);
-static void *__havoc_block(unsigned long size) {
+extern size_t __VERIFIER_nondet_size_t(void);
+extern void __VERIFIER_nondet_memory(void *, size_t);
+static void *__havoc_block(size_t size) {
   void *block = malloc(size);
   __VERIFIER_nondet_memory(block, size);
   return block;
 }
-static char *__havoc_cstring(unsigned long size) {
+static char *__havoc_cstring(size_t size) {
   char *s = __havoc_block(size);
-  s[size - 1] = '\0';
+  size_t len = __VERIFIER_nondet_size_t();
+  if (len >= size) abort();
+  s[len] = '\0';
   return s;
 }
 

--- a/tests/transform/cases/include-strip-local.expected.c
+++ b/tests/transform/cases/include-strip-local.expected.c
@@ -1,16 +1,19 @@
 
 
+#include <stdlib.h>
 extern int __VERIFIER_nondet_int(void);
-extern void __VERIFIER_nondet_memory(void *, unsigned long);
-extern void *malloc(unsigned long);
-static void *__havoc_block(unsigned long size) {
+extern size_t __VERIFIER_nondet_size_t(void);
+extern void __VERIFIER_nondet_memory(void *, size_t);
+static void *__havoc_block(size_t size) {
   void *block = malloc(size);
   __VERIFIER_nondet_memory(block, size);
   return block;
 }
-static char *__havoc_cstring(unsigned long size) {
+static char *__havoc_cstring(size_t size) {
   char *s = __havoc_block(size);
-  s[size - 1] = '\0';
+  size_t len = __VERIFIER_nondet_size_t();
+  if (len >= size) abort();
+  s[len] = '\0';
   return s;
 }
 

--- a/tests/transform/cases/main-gen-argc-argv.expected.c
+++ b/tests/transform/cases/main-gen-argc-argv.expected.c
@@ -1,14 +1,20 @@
+#include <stdlib.h>
+#define __HAVOC_ARGC_MIN 1
+#define __HAVOC_ARGC_MAX 4
+#define __HAVOC_STR_MAX 16
 extern int __VERIFIER_nondet_int(void);
-extern void __VERIFIER_nondet_memory(void *, unsigned long);
-extern void *malloc(unsigned long);
-static void *__havoc_block(unsigned long size) {
+extern size_t __VERIFIER_nondet_size_t(void);
+extern void __VERIFIER_nondet_memory(void *, size_t);
+static void *__havoc_block(size_t size) {
   void *block = malloc(size);
   __VERIFIER_nondet_memory(block, size);
   return block;
 }
-static char *__havoc_cstring(unsigned long size) {
+static char *__havoc_cstring(size_t size) {
   char *s = __havoc_block(size);
-  s[size - 1] = '\0';
+  size_t len = __VERIFIER_nondet_size_t();
+  if (len >= size) abort();
+  s[len] = '\0';
   return s;
 }
 
@@ -22,12 +28,11 @@ int original_main(int argc, char *argv[]) {
 
 int main(void) {
   helper(__VERIFIER_nondet_int());
-  extern void abort(void);
   int argc = __VERIFIER_nondet_int();
-  if (argc < 0 || argc > 7) abort();
-  char *argv[argc + 1];
+  if (argc < __HAVOC_ARGC_MIN || argc > __HAVOC_ARGC_MAX) abort();
+  char *argv[__HAVOC_ARGC_MAX + 1];
   for (int i = 0; i < argc; i++)
-    argv[i] = __havoc_cstring(16);
+    argv[i] = __havoc_cstring(__HAVOC_STR_MAX);
   argv[argc] = 0;
   original_main(argc, argv);
   return 0;

--- a/tests/verify/VerifyStageTest.cpp
+++ b/tests/verify/VerifyStageTest.cpp
@@ -249,6 +249,38 @@ TEST_F(VerifyStageTest, KeepCompilesOnlyDiscardsUndefinedTypes) {
   EXPECT_FALSE(fs::exists(benchmarkDir / "badtype.yml"));
 }
 
+TEST_F(VerifyStageTest, AssertRewriteAddsUnreachCallProperty) {
+  // assert(cond) is rewritten to reach_error() by the transform stage;
+  // reach_error must be exempt from the post-transform threshold re-check
+  // (isVerifierGenerated) or its trivial body would get stripped, and its
+  // presence in the reparsed counts should add unreach-call.prp.
+  writeFile(filterDir / "checked.c",
+            "#include <assert.h>\n"
+            "int add(int a, int b) {\n"
+            "  int r = a + b;\n"
+            "  assert(r >= a);\n"
+            "  return r;\n"
+            "}\n");
+
+  int count = transformAndVerify();
+
+  EXPECT_GE(count, 1);
+  ASSERT_TRUE(fs::exists(benchmarkDir / "checked.c"));
+  ASSERT_TRUE(fs::exists(benchmarkDir / "checked.yml"));
+
+  std::string src = readFile(benchmarkDir / "checked.c");
+  EXPECT_NE(src.find("void reach_error(void) { assert(0); }"), std::string::npos);
+  EXPECT_NE(src.find("if (!(r >= a)) reach_error();"), std::string::npos);
+  // AddVerifiersConsumer unconditionally adds its own #include <assert.h>
+  // alongside the reach_error definition, so this may duplicate the one
+  // already in the source; that's harmless since assert.h is deliberately
+  // unguarded against re-inclusion, so only presence is checked here.
+  EXPECT_NE(src.find("#include <assert.h>"), std::string::npos);
+
+  std::string yml = readFile(benchmarkDir / "checked.yml");
+  EXPECT_NE(yml.find("unreach-call.prp"), std::string::npos);
+}
+
 TEST_F(VerifyStageTest, ArgcArgvMainSurvivesVerify) {
   // original_main takes (int, char**): the verify re-check must not trip
   // over its unsupported params (no param check post-transform) and the


### PR DESCRIPTION
Adds support for #73 and #75 
- `CountingVisitor` now tracks existence of pointer, array, and allocation actions. Any of which indicate possible memory 'unsafety'
- Transform stage identifies `assert()` usage and converts it to an `unreach-call` by negating the gating condition
- Verify stage check for existence of `memsafety` related features and `reach_error` to add respective properties in task file