### PR TITLE
Task/#74/natsteven/std header handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SOURCE_TRANSFORM
   src/transform/HavocCallsConsumer.cpp
   src/transform/TransformAction.cpp
   src/transform/Transformer.cpp
+  src/transform/UnknownTypeDiagConsumer.cpp
 )
 
 set(SOURCE_VERIFY

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -134,9 +134,7 @@ Filter and Transform resolve each file's quoted `#include "..."` directives agai
 `extraIncludeDirs`) so project-local headers actually parse instead of just being
 stripped later. Basename collisions across the tree are disambiguated only by rebasing
 the include's own subdirectory components onto the candidate directory; a spec with no
-subdirectory that still matches more than one candidate just takes the first - a known,
-flagged TODO (`resolveIncludeDir` in `IncludeIndex.hpp`), safe by construction since an
-unresolved include just falls back to today's stripped behavior.
+subdirectory that still matches more than one candidate just takes the closest one.
 
 ### Preprocessor-Gated Code
 

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -117,6 +117,27 @@ project header are recovered by `AddStdIncludesConsumer` (see `CLAUDE.md`). File
 depend on *project* types or macros from a local header will still fail to compile after
 stripping and are caught by the Verify stage's `keepCompilesOnly` compile check.
 
+An unresolved type isn't always AST-visible for `AddStdIncludesConsumer` to recover: a
+local variable declared with an unrecognized type name (e.g. `mode_t m;` with no
+`sys/types.h` in scope) causes Clang to drop the whole `DeclStmt`, leaving no node to
+walk. `UnknownTypeDiagConsumer` closes this gap by hooking the parser's diagnostics
+directly (`err_unknown_typename`, and - the common case for a bare local declaration,
+which is syntactically ambiguous with an expression-statement - `err_undeclared_var_use`)
+and feeding the recovered names into the same `StdHeaders` lookup, name-only and
+backstopped by the same compile check.
+
+### Local Header Resolution
+
+Filter and Transform resolve each file's quoted `#include "..."` directives against a
+`HeaderIndex` (`src/common/include/IncludeIndex.hpp`) built once per run over
+`databaseDir`, passing matches to Clang as `-I` search paths (`runToolOnFile`'s
+`extraIncludeDirs`) so project-local headers actually parse instead of just being
+stripped later. Basename collisions across the tree are disambiguated only by rebasing
+the include's own subdirectory components onto the candidate directory; a spec with no
+subdirectory that still matches more than one candidate just takes the first - a known,
+flagged TODO (`resolveIncludeDir` in `IncludeIndex.hpp`), safe by construction since an
+unresolved include just falls back to today's stripped behavior.
+
 ### Preprocessor-Gated Code
 
 The pipeline only operates on the **active** preprocessed translation unit. Functions inside

--- a/src/common/include/ClangToolUtils.hpp
+++ b/src/common/include/ClangToolUtils.hpp
@@ -118,12 +118,18 @@ inline std::optional<std::string> clangCommand(const std::string &flags) {
  * {@code CommonOptionsParser} build a {@code FixedCompilationDatabase}
  * directly instead of searching for a {@code compile_commands.json}.
  *
- * @param filePath    Path to the C source file to process.
- * @param resourceDir Value from {@code getResourceDir}.
+ * @param filePath        Path to the C source file to process.
+ * @param resourceDir     Value from {@code getResourceDir}.
+ * @param extraIncludeDirs Directories to add as -I search paths (e.g. from
+ *                         {@code collectLocalIncludeDirs}), so quoted
+ *                         #includes the preprocessor's default search
+ *                         (current file's directory, then system paths)
+ *                         wouldn't otherwise find can still resolve.
  * @return Argument vector for {@code CommonOptionsParser::create}.
  */
 inline std::vector<std::string> buildClangArgs(const std::string &filePath,
-                                               const std::string &resourceDir) {
+                                               const std::string &resourceDir,
+                                               const std::vector<std::string> &extraIncludeDirs = {}) {
   std::vector<std::string> args = {
       "clang",
       filePath,
@@ -132,6 +138,8 @@ inline std::vector<std::string> buildClangArgs(const std::string &filePath,
       "-resource-dir=" + resourceDir,
       "-fparse-all-comments",
   };
+  for (const std::string &dir : extraIncludeDirs)
+    args.push_back("-I" + dir);
   std::optional<std::string> sysroot = getSysroot();
   if (sysroot) {
     args.push_back("-isysroot");
@@ -165,12 +173,14 @@ inline std::vector<const char *> toArgv(const std::vector<std::string> &args) {
  * but still count as a successful run; downstream compile checks decide the
  * output's fate.
  *
- * @param filePath Path to the C source file to process.
- * @param factory  Factory producing the FrontendAction to run.
+ * @param filePath        Path to the C source file to process.
+ * @param factory         Factory producing the FrontendAction to run.
+ * @param extraIncludeDirs Directories to add as -I search paths; see {@code buildClangArgs}.
  * @return true if the tool ran; false if setup failed (no resource dir, unparsable options).
  */
 inline bool runToolOnFile(const std::string &filePath,
-                          clang::tooling::FrontendActionFactory &factory) {
+                          clang::tooling::FrontendActionFactory &factory,
+                          const std::vector<std::string> &extraIncludeDirs = {}) {
   static llvm::cl::OptionCategory toolCategory("argv-c-transformer");
   clang::IgnoringDiagConsumer diagConsumer;
 
@@ -180,7 +190,7 @@ inline bool runToolOnFile(const std::string &filePath,
     return false;
   }
 
-  std::vector<std::string> args = buildClangArgs(filePath, *resourceDir);
+  std::vector<std::string> args = buildClangArgs(filePath, *resourceDir, extraIncludeDirs);
   std::vector<const char *> argv = toArgv(args);
   int argc = static_cast<int>(args.size());
 

--- a/src/common/include/IncludeIndex.hpp
+++ b/src/common/include/IncludeIndex.hpp
@@ -13,17 +13,18 @@
 #include <unordered_map>
 #include <vector>
 
+/** IncludeIndex is a fallback utility for finding header files when they aren't
+ * within the source's directory tree. Without a compile_commands.json we must
+ * find the correct headers and use a nearness heuristic for disambuguation.
+ */
+
 /**
  * @brief Maps header basenames to every directory under a root tree that
  * contains a file with that name.
- *
- * Built once per pipeline run (over databaseDir) and reused across every file
- * being filtered/transformed, so resolving one file's #includes doesn't
- * re-walk the whole tree.
  */
 class HeaderIndex {
 public:
-  /** @brief Recursively scans `root` for .h files. A missing/empty root leaves the index empty. */
+  /** @brief Scans `root` for .h files (missing/empty root -> empty index). */
   explicit HeaderIndex(const std::filesystem::path &root) {
     if (root.empty() || !std::filesystem::exists(root))
       return;
@@ -42,7 +43,7 @@ public:
     }
   }
 
-  /** @brief Directories under root containing a file named `basename`, or nullptr if none. */
+  /** @brief Directories containing a file named `basename`, or nullptr if none. */
   const std::vector<std::filesystem::path> *find(const std::string &basename) const {
     auto it = _byBasename.find(basename);
     return it == _byBasename.end() ? nullptr : &it->second;
@@ -52,7 +53,7 @@ private:
   std::unordered_map<std::string, std::vector<std::filesystem::path>> _byBasename;
 };
 
-/** @brief Extracts the filenames named by quoted `#include "..."` directives (angle-bracket includes are assumed to be system/library headers and are skipped). */
+/** @brief Extracts the text of every quoted `#include "..."`*/
 inline std::vector<std::string> extractQuotedIncludes(const std::filesystem::path &filePath) {
   static const std::regex quoted(R"re(^\s*#\s*include\s*"([^"]+)")re");
   std::vector<std::string> includes;
@@ -67,23 +68,21 @@ inline std::vector<std::string> extractQuotedIncludes(const std::filesystem::pat
 }
 
 /**
- * @brief Strips `includeSpec`'s own subdirectory components off the end of
- * `candidateDir` (the directory a matching header actually lives in), giving
- * the -I root that would make `includeSpec` resolve to that header.
+ * @brief Turns a header hit into the -I root that would make `includeQuote`
+ * resolve to it
  *
- * E.g. includeSpec "nested/mytypes.h" against candidateDir
- * "repo/include/nested" rebases to "repo/include" - the -I flag has to name
- * the directory the quoted path is relative to, not the header's own parent.
- * Returns nullopt if candidateDir doesn't structurally end with those
- * components (the basename match was coincidental).
+ * E.g. includeQuote "nested/mytypes.h" against candidateDir
+ * "repo/include/nested" rebases to "repo/include". Returns nullopt if
+ * candidateDir doesn't structurally end with those components - i.e. the
+ * basename match was coincidental (an unrelated file of the same name).
  */
 inline std::optional<std::filesystem::path> rebaseToIncludeRoot(std::filesystem::path candidateDir,
-                                                                 const std::string &includeSpec) {
-  std::filesystem::path specDir = std::filesystem::path(includeSpec).parent_path();
+                                                                 const std::string &includeQuote) {
+  std::filesystem::path quoteDir = std::filesystem::path(includeQuote).parent_path();
   std::vector<std::string> parts;
-  for (const std::filesystem::path &part : specDir)
+  for (const std::filesystem::path &part : quoteDir)
     parts.push_back(part.string());
-  // specDir's components read left-to-right ("a/b"), but they need to be
+  // quoteDir's components read left-to-right ("a/b"), but they need to be
   // peeled off candidateDir's end innermost-first, i.e. "b" then "a".
   for (auto part = parts.rbegin(); part != parts.rend(); ++part) {
     if (candidateDir.filename() != *part)
@@ -94,61 +93,50 @@ inline std::optional<std::filesystem::path> rebaseToIncludeRoot(std::filesystem:
 }
 
 /**
- * @brief Picks the -I directory for one quoted #include spec out of a
- * HeaderIndex's basename candidates.
+ * @brief Picks the -I directory for one quoted #include out of a
+ * HeaderIndex's basename candidates, via `rebaseToIncludeRoot`.
  *
- * Candidates are first rebased with `rebaseToIncludeRoot`: for a spec with
- * subdirectory components (e.g. "sub/foo.h") only directories that
- * structurally agree with those components count - anything else is a
- * same-basename false positive (e.g. an unrelated vendored copy) and is
- * dropped rather than risk pointing -I at the wrong tree.
+ * Note this is for the case a quoted include does *not* resolve against the
+ * including file's own directory. Picks a header with the shortest
+ * `sourceDir`-relative path, i.e. structurally nearest the including file
  *
- * TODO(you): once rebasing narrows things down, more than one confident
- * candidate can still remain (e.g. the header spec has no subdirectory at
- * all, or the same relative suffix exists under two different subtrees).
- * This placeholder just takes the first one, ignoring everything else about
- * the include site. Replace it with real disambiguation - e.g. prefer the
- * candidate closest to `sourceDir` (the .c file's own directory) by path
- * distance, or shortest path, or first found; there's no single right
- * answer, pick one and leave a one-line note why. Returning `nullopt`
- * instead (no -I added for this include) is always safe: a skipped include
- * just stays unresolved, same as today's behavior.
- *
- * @param includeSpec Text of the quoted include, e.g. "sub/foo.h".
- * @param index       Prebuilt index of headers under the tree being searched.
- * @param sourceDir   Directory containing the file that has this #include.
- * @return The directory to pass as -I, or nullopt if no confident match.
+ * @param includeQuote Text of the quoted include, e.g. "sub/foo.h".
+ * @param index        Prebuilt index of headers under the tree being searched.
+ * @param sourceDir    Directory containing the file that has this #include.
+ * @return The directory to pass as -I, or nullopt if no candidate at all.
  */
-inline std::optional<std::filesystem::path> resolveIncludeDir(const std::string &includeSpec,
+inline std::optional<std::filesystem::path> resolveIncludeDir(const std::string &includeQuote,
                                                                const HeaderIndex &index,
                                                                const std::filesystem::path &sourceDir) {
-  (void)sourceDir;
-  std::string basename = std::filesystem::path(includeSpec).filename().string();
+  std::string basename = std::filesystem::path(includeQuote).filename().string();
   const std::vector<std::filesystem::path> *candidates = index.find(basename);
   if (!candidates || candidates->empty())
     return std::nullopt;
 
-  std::vector<std::filesystem::path> rebased;
+  std::optional<std::filesystem::path> best;
+  std::size_t bestDistance = 0;
   for (const std::filesystem::path &candidate : *candidates) {
-    std::optional<std::filesystem::path> root = rebaseToIncludeRoot(candidate, includeSpec);
-    if (root)
-      rebased.push_back(*root);
+    std::optional<std::filesystem::path> root = rebaseToIncludeRoot(candidate, includeQuote);
+    if (!root)
+      continue;
+    std::error_code ec;
+    std::filesystem::path rel = std::filesystem::relative(*root, sourceDir, ec);
+    std::size_t distance = ec ? std::string::npos : std::distance(rel.begin(), rel.end());
+    if (!best || distance < bestDistance) {
+      best = root;
+      bestDistance = distance;
+    }
   }
-  if (rebased.empty())
-    return std::nullopt;
-  return rebased.front();
+  return best;
 }
 
-/**
- * @brief Resolves every quoted #include in `filePath` to a -I directory via
- * `resolveIncludeDir`, deduplicated and in first-seen order.
- */
+/** @brief Resolves every quoted #include in `filePath` to a -I dir via `resolveIncludeDir`, deduplicated, first-seen order. */
 inline std::vector<std::string> collectLocalIncludeDirs(const std::filesystem::path &filePath,
                                                          const HeaderIndex &index) {
   std::vector<std::string> dirs;
-  for (const std::string &spec : extractQuotedIncludes(filePath)) {
+  for (const std::string &quote : extractQuotedIncludes(filePath)) {
     std::optional<std::filesystem::path> dir =
-        resolveIncludeDir(spec, index, filePath.parent_path());
+        resolveIncludeDir(quote, index, filePath.parent_path());
     if (!dir)
       continue;
     std::string s = dir->string();

--- a/src/common/include/IncludeIndex.hpp
+++ b/src/common/include/IncludeIndex.hpp
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 The ARG-V Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <regex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @brief Maps header basenames to every directory under a root tree that
+ * contains a file with that name.
+ *
+ * Built once per pipeline run (over databaseDir) and reused across every file
+ * being filtered/transformed, so resolving one file's #includes doesn't
+ * re-walk the whole tree.
+ */
+class HeaderIndex {
+public:
+  /** @brief Recursively scans `root` for .h files. A missing/empty root leaves the index empty. */
+  explicit HeaderIndex(const std::filesystem::path &root) {
+    if (root.empty() || !std::filesystem::exists(root))
+      return;
+    std::error_code ec;
+    auto it = std::filesystem::recursive_directory_iterator(
+        root, std::filesystem::directory_options::skip_permission_denied, ec);
+    auto end = std::filesystem::recursive_directory_iterator();
+    for (; !ec && it != end; it.increment(ec)) {
+      const std::filesystem::path &p = it->path();
+      std::error_code fileEc;
+      if (!it->is_regular_file(fileEc) || fileEc)
+        continue;
+      std::string ext = p.extension().string();
+      if (ext == ".h")
+        _byBasename[p.filename().string()].push_back(p.parent_path());
+    }
+  }
+
+  /** @brief Directories under root containing a file named `basename`, or nullptr if none. */
+  const std::vector<std::filesystem::path> *find(const std::string &basename) const {
+    auto it = _byBasename.find(basename);
+    return it == _byBasename.end() ? nullptr : &it->second;
+  }
+
+private:
+  std::unordered_map<std::string, std::vector<std::filesystem::path>> _byBasename;
+};
+
+/** @brief Extracts the filenames named by quoted `#include "..."` directives (angle-bracket includes are assumed to be system/library headers and are skipped). */
+inline std::vector<std::string> extractQuotedIncludes(const std::filesystem::path &filePath) {
+  static const std::regex quoted(R"re(^\s*#\s*include\s*"([^"]+)")re");
+  std::vector<std::string> includes;
+  std::ifstream in(filePath);
+  std::string line;
+  while (std::getline(in, line)) {
+    std::smatch m;
+    if (std::regex_search(line, m, quoted))
+      includes.push_back(m[1].str());
+  }
+  return includes;
+}
+
+/**
+ * @brief Strips `includeSpec`'s own subdirectory components off the end of
+ * `candidateDir` (the directory a matching header actually lives in), giving
+ * the -I root that would make `includeSpec` resolve to that header.
+ *
+ * E.g. includeSpec "nested/mytypes.h" against candidateDir
+ * "repo/include/nested" rebases to "repo/include" - the -I flag has to name
+ * the directory the quoted path is relative to, not the header's own parent.
+ * Returns nullopt if candidateDir doesn't structurally end with those
+ * components (the basename match was coincidental).
+ */
+inline std::optional<std::filesystem::path> rebaseToIncludeRoot(std::filesystem::path candidateDir,
+                                                                 const std::string &includeSpec) {
+  std::filesystem::path specDir = std::filesystem::path(includeSpec).parent_path();
+  std::vector<std::string> parts;
+  for (const std::filesystem::path &part : specDir)
+    parts.push_back(part.string());
+  // specDir's components read left-to-right ("a/b"), but they need to be
+  // peeled off candidateDir's end innermost-first, i.e. "b" then "a".
+  for (auto part = parts.rbegin(); part != parts.rend(); ++part) {
+    if (candidateDir.filename() != *part)
+      return std::nullopt;
+    candidateDir = candidateDir.parent_path();
+  }
+  return candidateDir;
+}
+
+/**
+ * @brief Picks the -I directory for one quoted #include spec out of a
+ * HeaderIndex's basename candidates.
+ *
+ * Candidates are first rebased with `rebaseToIncludeRoot`: for a spec with
+ * subdirectory components (e.g. "sub/foo.h") only directories that
+ * structurally agree with those components count - anything else is a
+ * same-basename false positive (e.g. an unrelated vendored copy) and is
+ * dropped rather than risk pointing -I at the wrong tree.
+ *
+ * TODO(you): once rebasing narrows things down, more than one confident
+ * candidate can still remain (e.g. the header spec has no subdirectory at
+ * all, or the same relative suffix exists under two different subtrees).
+ * This placeholder just takes the first one, ignoring everything else about
+ * the include site. Replace it with real disambiguation - e.g. prefer the
+ * candidate closest to `sourceDir` (the .c file's own directory) by path
+ * distance, or shortest path, or first found; there's no single right
+ * answer, pick one and leave a one-line note why. Returning `nullopt`
+ * instead (no -I added for this include) is always safe: a skipped include
+ * just stays unresolved, same as today's behavior.
+ *
+ * @param includeSpec Text of the quoted include, e.g. "sub/foo.h".
+ * @param index       Prebuilt index of headers under the tree being searched.
+ * @param sourceDir   Directory containing the file that has this #include.
+ * @return The directory to pass as -I, or nullopt if no confident match.
+ */
+inline std::optional<std::filesystem::path> resolveIncludeDir(const std::string &includeSpec,
+                                                               const HeaderIndex &index,
+                                                               const std::filesystem::path &sourceDir) {
+  (void)sourceDir;
+  std::string basename = std::filesystem::path(includeSpec).filename().string();
+  const std::vector<std::filesystem::path> *candidates = index.find(basename);
+  if (!candidates || candidates->empty())
+    return std::nullopt;
+
+  std::vector<std::filesystem::path> rebased;
+  for (const std::filesystem::path &candidate : *candidates) {
+    std::optional<std::filesystem::path> root = rebaseToIncludeRoot(candidate, includeSpec);
+    if (root)
+      rebased.push_back(*root);
+  }
+  if (rebased.empty())
+    return std::nullopt;
+  return rebased.front();
+}
+
+/**
+ * @brief Resolves every quoted #include in `filePath` to a -I directory via
+ * `resolveIncludeDir`, deduplicated and in first-seen order.
+ */
+inline std::vector<std::string> collectLocalIncludeDirs(const std::filesystem::path &filePath,
+                                                         const HeaderIndex &index) {
+  std::vector<std::string> dirs;
+  for (const std::string &spec : extractQuotedIncludes(filePath)) {
+    std::optional<std::filesystem::path> dir =
+        resolveIncludeDir(spec, index, filePath.parent_path());
+    if (!dir)
+      continue;
+    std::string s = dir->string();
+    if (std::find(dirs.begin(), dirs.end(), s) == dirs.end())
+      dirs.push_back(s);
+  }
+  return dirs;
+}

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -138,6 +138,10 @@ int Filterer::run() {
   int filesFound = getAllCFiles(pathObject, filesToFilter, 0);
   debugLog(1, "[filter] found " + std::to_string(filesFound) + " .c file(s)");
 
+  // Built once and reused for every file below, so resolving local
+  // #includes to -I paths doesn't re-walk databaseDir per file.
+  headerIndex.emplace(configuration.databaseDir);
+
   int passed = 0;
   int i = 0;
   for (const std::string &fileName : filesToFilter) {
@@ -170,8 +174,10 @@ int Filterer::run() {
       continue;
     }
 
+    std::vector<std::string> includeDirs = collectLocalIncludeDirs(oldPath, *headerIndex);
+
     FrontendFactoryWithArgs factory(&config.complexity, &config.features, output);
-    bool ran = runToolOnFile(oldPath.string(), factory);
+    bool ran = runToolOnFile(oldPath.string(), factory, includeDirs);
     output.close();
     if (!ran) {
       debugLog(1, "[filter] clang tool failed on: " + oldPath.string());

--- a/src/filter/include/Filterer.hpp
+++ b/src/filter/include/Filterer.hpp
@@ -5,8 +5,10 @@
 #pragma once
 
 #include "ConfigParser.hpp"
+#include "IncludeIndex.hpp"
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -96,6 +98,15 @@ public:
    */
   const std::string &getFilterDir() const { return configuration.filterDir; }
 
+  /**
+   * @brief Returns the resolved input tree the filter read from.
+   *
+   * Lets the full pipeline point the transform step's local-#include
+   * resolution back at the real repo tree (filterDir only mirrors .c files,
+   * not headers), whichever of default / config / derived-from-input won.
+   */
+  const std::string &getDatabaseDir() const { return configuration.databaseDir; }
+
 private:
   /// Thresholds, feature gates, and file settings from the shared config
   /// parser; the same structure the verify stage re-applies post-transform.
@@ -103,4 +114,8 @@ private:
 
   /// Path settings and flags that don't fit either config map.
   struct filterConfigs configuration;
+
+  /// Header basename → directory index over databaseDir, built once in run()
+  /// and used to resolve each file's quoted #includes to -I search paths.
+  std::optional<HeaderIndex> headerIndex;
 };

--- a/src/full/main.cpp
+++ b/src/full/main.cpp
@@ -37,7 +37,6 @@ int main(int argc, char **argv) {
   Transformer transformer(invocation->configFile, transformInput);
   // filter's resolved input tree, so transform can resolve local #includes
   // against it too (filterDir only mirrors .c files, not headers).
-  transformer.setDatabaseDir(filter.getDatabaseDir());
   transformer.run();
 
   // Verify always reads the transform's resolved output directory, whichever

--- a/src/full/main.cpp
+++ b/src/full/main.cpp
@@ -35,6 +35,9 @@ int main(int argc, char **argv) {
   if (!invocation->inputPath.empty())
     transformInput = filter.getFilterDir();
   Transformer transformer(invocation->configFile, transformInput);
+  // filter's resolved input tree, so transform can resolve local #includes
+  // against it too (filterDir only mirrors .c files, not headers).
+  transformer.setDatabaseDir(filter.getDatabaseDir());
   transformer.run();
 
   // Verify always reads the transform's resolved output directory, whichever

--- a/src/full/main.cpp
+++ b/src/full/main.cpp
@@ -37,6 +37,7 @@ int main(int argc, char **argv) {
   Transformer transformer(invocation->configFile, transformInput);
   // filter's resolved input tree, so transform can resolve local #includes
   // against it too (filterDir only mirrors .c files, not headers).
+  transformer.setDatabaseDir(filter.getDatabaseDir());
   transformer.run();
 
   // Verify always reads the transform's resolved output directory, whichever

--- a/src/transform/AddStdIncludesConsumer.cpp
+++ b/src/transform/AddStdIncludesConsumer.cpp
@@ -112,8 +112,10 @@ private:
 }// namespace
 
 AddStdIncludesConsumer::AddStdIncludesConsumer(
-    std::shared_ptr<std::set<std::string>> existingIncludes, clang::Rewriter &rewriter)
-    : _ExistingIncludes(existingIncludes), _Rewriter(rewriter) {
+    std::shared_ptr<std::set<std::string>> existingIncludes,
+    std::shared_ptr<std::set<std::string>> unresolvedTypeNames, clang::Rewriter &rewriter)
+    : _ExistingIncludes(existingIncludes), _UnresolvedTypeNames(unresolvedTypeNames),
+      _Rewriter(rewriter) {
 }
 
 void AddStdIncludesConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
@@ -137,6 +139,13 @@ void AddStdIncludesConsumer::HandleTranslationUnit(clang::ASTContext &Context) {
       continue;
     includes += "#include <" + header + ">\n";
     _ExistingIncludes->insert(header);
+  }
+  for (const std::string &name : *_UnresolvedTypeNames) {
+    auto it = StdHeaders.find(name);
+    if (it == StdHeaders.end() || _ExistingIncludes->count(it->second))
+      continue;
+    includes += "#include <" + it->second + ">\n";
+    _ExistingIncludes->insert(it->second);
   }
 
   if (includes.empty())

--- a/src/transform/HavocCallsVisitor.cpp
+++ b/src/transform/HavocCallsVisitor.cpp
@@ -7,9 +7,11 @@
 #include "DebugLog.hpp"
 #include "VerifierNames.hpp"
 
+#include <clang/AST/ASTTypeTraits.h>
 #include <clang/AST/DeclBase.h>
 #include <clang/AST/Expr.h>
 #include <clang/AST/OperationKinds.h>
+#include <clang/AST/ParentMapContext.h>
 #include <clang/AST/RecursiveASTVisitor.h>
 #include <clang/AST/Stmt.h>
 #include <clang/Basic/SourceManager.h>
@@ -155,6 +157,15 @@ bool HavocCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
   clang::QualType returnType = E->getCallReturnType(*_C);
   if (returnType.isNull() || returnType.getTypePtrOrNull() == nullptr)
     return true;
+  bool parentIsExpr = false;
+  clang::DynTypedNodeList parents = _C->getParents(*E);
+  for (clang::DynTypedNode parent: parents) {
+    if (const clang::Stmt *parentStmt = parent.get<clang::Stmt>()) {
+      if (clang::isa<clang::Expr>(parentStmt)) {
+        parentIsExpr = true;
+    }
+  }
+
   if (returnType->isVoidType()) {
     // A void call yields no value to havoc; drop it (the statement's
     // semicolon stays behind, leaving an empty statement). Mark it a no-op so

--- a/src/transform/HavocCallsVisitor.cpp
+++ b/src/transform/HavocCallsVisitor.cpp
@@ -157,14 +157,6 @@ bool HavocCallsVisitor::VisitCallExpr(clang::CallExpr *E) {
   clang::QualType returnType = E->getCallReturnType(*_C);
   if (returnType.isNull() || returnType.getTypePtrOrNull() == nullptr)
     return true;
-  bool parentIsExpr = false;
-  clang::DynTypedNodeList parents = _C->getParents(*E);
-  for (clang::DynTypedNode parent: parents) {
-    if (const clang::Stmt *parentStmt = parent.get<clang::Stmt>()) {
-      if (clang::isa<clang::Expr>(parentStmt)) {
-        parentIsExpr = true;
-    }
-  }
 
   if (returnType->isVoidType()) {
     // A void call yields no value to havoc; drop it (the statement's

--- a/src/transform/TransformAction.cpp
+++ b/src/transform/TransformAction.cpp
@@ -8,6 +8,7 @@
 #include "DebugLog.hpp"
 #include "HavocCallsConsumer.hpp"
 #include "MainGenConsumer.hpp"
+#include "UnknownTypeDiagConsumer.hpp"
 
 #include <clang/Basic/SourceManager.h>
 #include <clang/Frontend/MultiplexConsumer.h>
@@ -76,7 +77,9 @@ AssertRewriter::AssertRewriter(clang::SourceManager &SM, clang::Rewriter &rewrit
                                const clang::LangOptions &langOpts)
     : _Mgr(SM), _Rewriter(rewriter), _NeededSuffixes(neededSuffixes), _LangOpts(langOpts) {}
 
-TransformAction::TransformAction(llvm::raw_ostream &output) : _Output(output), _Rewriter() {}
+TransformAction::TransformAction(llvm::raw_ostream &output)
+    : _Output(output), _Rewriter(),
+      _UnresolvedTypeNames(std::make_shared<std::set<std::string>>()) {}
 
 // unique_ptr can't be copied, so tempVector is built up and moved into MultiplexConsumer.
 std::unique_ptr<clang::ASTConsumer>
@@ -102,13 +105,18 @@ TransformAction::CreateASTConsumer(clang::CompilerInstance &compiler, llvm::Stri
   tempVector.emplace_back(
       std::make_unique<MainGenConsumer>(neededSuffixes, noOpFunctions, _Rewriter));
   tempVector.emplace_back(std::make_unique<AddVerifiersConsumer>(neededSuffixes, _Rewriter));
-  tempVector.emplace_back(std::make_unique<AddStdIncludesConsumer>(existingIncludes, _Rewriter));
+  tempVector.emplace_back(
+      std::make_unique<AddStdIncludesConsumer>(existingIncludes, _UnresolvedTypeNames, _Rewriter));
 
   return std::make_unique<clang::MultiplexConsumer>(std::move(tempVector));
 }
 
 bool TransformAction::BeginSourceFileAction(clang::CompilerInstance &compiler) {
   _Rewriter.setSourceMgr(compiler.getSourceManager(), compiler.getLangOpts());
+  // Ownership passes to the DiagnosticsEngine; it outlives parsing, which is
+  // all this consumer needs to run for.
+  compiler.getDiagnostics().setClient(new UnknownTypeDiagConsumer(_UnresolvedTypeNames),
+                                      /*ShouldOwnClient=*/true);
   return clang::ASTFrontendAction::BeginSourceFileAction(compiler);
 }
 

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -7,6 +7,7 @@
 #include "CliArgs.hpp"
 #include "ConfigParser.hpp"
 #include "DebugLog.hpp"
+#include "IncludeIndex.hpp"
 
 #include <csignal>
 #include <ctime>
@@ -16,6 +17,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <string>
 #include <system_error>
+#include <vector>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -81,8 +83,14 @@ bool Transformer::transformFile(std::filesystem::path path) {
     return false;
   }
 
+  // The filtered file still carries its original quoted #includes, but only
+  // the source repo has the headers they name, so they resolve against that
+  // tree. An unset databaseDir leaves the index empty and the list empty.
+  std::vector<std::string> includeDirs =
+      headerIndex ? collectLocalIncludeDirs(path, *headerIndex) : std::vector<std::string>{};
+
   ArgsFrontendFactory factory(output);
-  bool ran = runToolOnFile(path.string(), factory);
+  bool ran = runToolOnFile(path.string(), factory, includeDirs);
   output.close();
   if (!ran) {
     debugLog(1, "[transform] clang tool failed on: " + path.string());
@@ -195,6 +203,14 @@ void Transformer::parseConfig(std::string configFile) {
   if (!config.filterDir.empty()) {
     configuration.filterDir = config.filterDir;
   }
+  // The filtered tree holds only .c files, so quoted #includes still have to
+  // resolve against the original repo. argv-c injects this via
+  // setDatabaseDir(); a standalone `transform` run only has the config.
+  if (!config.databaseDir.empty()) {
+    configuration.databaseDir = config.databaseDir;
+    if (!std::filesystem::exists(config.databaseDir))
+      debugLog(0, "Database directory not found: " + config.databaseDir);
+  }
 }
 
 int Transformer::run() {
@@ -203,6 +219,10 @@ int Transformer::run() {
     debugLog(0, "Filter directory not found: " + configuration.filterDir);
     return 0;
   }
+  // Built once over the original repo tree, before any file is transformed;
+  // transformFile runs in a forked child, which inherits the index as-is.
+  headerIndex.emplace(configuration.databaseDir);
+
   int result = transformAll(path);
   int discarded = _totalProcessed - result;
   std::cout << "\n=== Transform summary ===\n"

--- a/src/transform/UnknownTypeDiagConsumer.cpp
+++ b/src/transform/UnknownTypeDiagConsumer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "UnknownTypeDiagConsumer.hpp"
+#include "DebugLog.hpp"
 
 #include <clang/AST/DeclarationName.h>
 #include <clang/Basic/DiagnosticSema.h>
@@ -23,17 +24,18 @@ void UnknownTypeDiagConsumer::HandleDiagnostic(clang::DiagnosticsEngine::Level,
   if (!isUnknownTypename && !isUndeclaredVarUse)
     return;
 
-  // Guarded rather than asserted: a future Clang version
-  // streaming either differently should silently miss the recovery rather
-  // than crash a whole batch run, consistent with this consumer's
-  // best-effort, compile-check-backstopped nature.
+  // Guarded against a future Clang version diagnostic change
   if (isUnknownTypename) {
-    if (Info.getArgKind(0) != clang::DiagnosticsEngine::ak_identifierinfo)
-      return;
+    if (Info.getArgKind(0) != clang::DiagnosticsEngine::ak_identifierinfo){
+      debugLog(0, "ERROR: Potential Clang Version Issue in UnknownTypeDiag recovery");
+      exit(-1);
+    }
     _UnresolvedTypeNames->insert(Info.getArgIdentifier(0)->getName().str());
   } else {
-    if (Info.getArgKind(0) != clang::DiagnosticsEngine::ak_declarationname)
-      return;
+    if (Info.getArgKind(0) != clang::DiagnosticsEngine::ak_declarationname) {
+      debugLog(0, "ERROR: Potential Clang Version Issue in UnknownTypeDiag recovery");
+      exit(-1);
+    }
     clang::DeclarationName name = clang::DeclarationName::getFromOpaqueInteger(Info.getRawArg(0));
     _UnresolvedTypeNames->insert(name.getAsString());
   }

--- a/src/transform/UnknownTypeDiagConsumer.cpp
+++ b/src/transform/UnknownTypeDiagConsumer.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 The ARG-V Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "UnknownTypeDiagConsumer.hpp"
+
+#include <clang/AST/DeclarationName.h>
+#include <clang/Basic/DiagnosticSema.h>
+#include <clang/Basic/IdentifierTable.h>
+
+UnknownTypeDiagConsumer::UnknownTypeDiagConsumer(
+    std::shared_ptr<std::set<std::string>> unresolvedTypeNames)
+    : _UnresolvedTypeNames(unresolvedTypeNames) {
+}
+
+void UnknownTypeDiagConsumer::HandleDiagnostic(clang::DiagnosticsEngine::Level,
+                                               const clang::Diagnostic &Info) {
+  unsigned id = Info.getID();
+  bool isUnknownTypename =
+      id == clang::diag::err_unknown_typename || id == clang::diag::err_unknown_typename_suggest;
+  bool isUndeclaredVarUse =
+      id == clang::diag::err_undeclared_var_use || id == clang::diag::err_undeclared_var_use_suggest;
+  if (!isUnknownTypename && !isUndeclaredVarUse)
+    return;
+
+  // Guarded rather than asserted: a future Clang version
+  // streaming either differently should silently miss the recovery rather
+  // than crash a whole batch run, consistent with this consumer's
+  // best-effort, compile-check-backstopped nature.
+  if (isUnknownTypename) {
+    if (Info.getArgKind(0) != clang::DiagnosticsEngine::ak_identifierinfo)
+      return;
+    _UnresolvedTypeNames->insert(Info.getArgIdentifier(0)->getName().str());
+  } else {
+    if (Info.getArgKind(0) != clang::DiagnosticsEngine::ak_declarationname)
+      return;
+    clang::DeclarationName name = clang::DeclarationName::getFromOpaqueInteger(Info.getRawArg(0));
+    _UnresolvedTypeNames->insert(name.getAsString());
+  }
+}

--- a/src/transform/include/AddStdIncludesConsumer.hpp
+++ b/src/transform/include/AddStdIncludesConsumer.hpp
@@ -27,9 +27,13 @@ public:
    *
    * @param existingIncludes System includes already present in the file (recorded
    *        by {@code IncludeFinder}); used to avoid emitting duplicates.
-   * @param rewriter         Shared rewriter for modifying the source buffer.
+   * @param unresolvedTypeNames Unresolved type identifiers recovered by
+   *        {@code UnknownTypeDiagConsumer} during parsing - names that never
+   *        made it into the AST 
+   * @param rewriter Shared rewriter for modifying the source buffer.
    */
   AddStdIncludesConsumer(std::shared_ptr<std::set<std::string>> existingIncludes,
+                         std::shared_ptr<std::set<std::string>> unresolvedTypeNames,
                          clang::Rewriter &rewriter);
 
   /**
@@ -41,5 +45,6 @@ public:
 
 private:
   std::shared_ptr<std::set<std::string>> _ExistingIncludes;
+  std::shared_ptr<std::set<std::string>> _UnresolvedTypeNames;
   clang::Rewriter &_Rewriter;
 };

--- a/src/transform/include/TransformAction.hpp
+++ b/src/transform/include/TransformAction.hpp
@@ -41,8 +41,9 @@ public:
    * @brief Builds the multiplexed consumer chain for the transform pipeline.
    *
    * Registers IncludeFinder on the preprocessor and returns a
-   * MultiplexConsumer running HavocCallsConsumer, MainGenConsumer, and
-   * AddVerifiersConsumer (in that order) over the shared Rewriter.
+   * MultiplexConsumer running HavocCallsConsumer, MainGenConsumer,
+   * AddVerifiersConsumer, and AddStdIncludesConsumer (in that order) over the
+   * shared Rewriter.
    *
    * @param Compiler The compiler instance for this translation unit.
    * @param Filename Name of the file being processed.
@@ -52,7 +53,9 @@ public:
                                                                 llvm::StringRef Filename) override;
 
   /**
-   * @brief Initializes the shared Rewriter before any consumers run.
+   * @brief Initializes the shared Rewriter and installs the unresolved-type diagnostic consumer.
+   *
+   * This runs before parsing starts, so every diagnostic for the translation unit is captured.
    *
    * @param compiler The compiler instance for this translation unit.
    * @return Result of the base class implementation.
@@ -67,6 +70,7 @@ public:
 private:
   llvm::raw_ostream &_Output;
   clang::Rewriter _Rewriter;
+  std::shared_ptr<std::set<std::string>> _UnresolvedTypeNames;
 };
 
 /**

--- a/src/transform/include/Transformer.hpp
+++ b/src/transform/include/Transformer.hpp
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include "IncludeIndex.hpp"
+
 #include <filesystem>
+#include <optional>
 #include <string>
 
 /**
@@ -18,6 +21,9 @@ struct transformConfigs {
   std::string filterDir;    ///< Input directory containing filtered C files to transform.
   std::string transformDir; ///< Output directory for transformed files (verify-stage input).
   int fileTimeoutSecs;      ///< Wall-clock budget per file for the isolated transform child.
+  /// Original repo tree the filtered files came from, used only to resolve
+  /// quoted #includes to -I paths. Empty means no local-header resolution.
+  std::string databaseDir;
 };
 
 /**
@@ -116,9 +122,21 @@ public:
    */
   const std::string &getTransformDir() const { return configuration.transformDir; }
 
+  /**
+   * @brief Points local-#include resolution at the original repo tree.
+   *
+   * filterDir only mirrors .c files, so a filtered file's quoted #includes
+   * can only be resolved against the tree the filter read from. Must be
+   * called before run(); the header index is built there.
+   */
+  void setDatabaseDir(const std::string &dir) { configuration.databaseDir = dir; }
+
 private:
   /// Path settings and flags loaded from the config file.
   struct transformConfigs configuration;
   /// Count of .c files attempted across the run, for the end-of-run summary.
   int _totalProcessed = 0;
+  /// Header basename → directory index over databaseDir, built once in run()
+  /// and used to resolve each file's quoted #includes to -I search paths.
+  std::optional<HeaderIndex> headerIndex;
 };

--- a/src/transform/include/UnknownTypeDiagConsumer.hpp
+++ b/src/transform/include/UnknownTypeDiagConsumer.hpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 The ARG-V Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <clang/Basic/Diagnostic.h>
+#include <memory>
+#include <set>
+#include <string>
+
+/**
+ * @brief DiagnosticConsumer that recovers unresolved standard type names lost to the AST.
+ *
+ * An unresolved type name in a local variable declaration causes Sema to drop
+ * the whole DeclStmt. The identifier is only ever
+ * observable in the diagnostic Clang emits while parsing.
+ *
+ * Two diagnostic families report this:
+ *  - `err_unknown_typename` (+ `_suggest`): the declaration is unambiguous
+ *    so Sema reports the unresolved type directly. Argument 0 is an `IdentifierInfo*`.
+ *  - `err_undeclared_var_use` (+ `_suggest`): a *bare* local declaration
+ *    is syntactically ambiguous, and Clang's heuristic guesses.
+ *    Argument 0 here is a `DeclarationName`.
+ * Both are matched by name only (`StdHeaders.hpp` lookup)
+ *
+ * Every other diagnostic is swallowed
+ */
+class UnknownTypeDiagConsumer : public clang::DiagnosticConsumer {
+public:
+  /**
+   * @brief Constructs the consumer, binding the shared output set.
+   *
+   * @param unresolvedTypeNames Populated with the spelled name of every
+   *        unresolved type identifier seen; read by AddStdIncludesConsumer
+   *        once parsing completes.
+   */
+  explicit UnknownTypeDiagConsumer(std::shared_ptr<std::set<std::string>> unresolvedTypeNames);
+
+  /**
+   * @brief Records the identifier of an unresolved-type diagnostic; ignores everything else.
+   *
+   * @param DiagLevel Severity of the diagnostic (unused - matched by ID only).
+   * @param Info      The diagnostic being reported, including its format arguments.
+   */
+  void HandleDiagnostic(clang::DiagnosticsEngine::Level DiagLevel,
+                        const clang::Diagnostic &Info) override;
+
+private:
+  std::shared_ptr<std::set<std::string>> _UnresolvedTypeNames;
+};

--- a/src/transform/include/UnknownTypeDiagConsumer.hpp
+++ b/src/transform/include/UnknownTypeDiagConsumer.hpp
@@ -12,33 +12,22 @@
 /**
  * @brief DiagnosticConsumer that recovers unresolved standard type names lost to the AST.
  *
- * An unresolved type name in a local variable declaration causes Sema to drop
- * the whole DeclStmt. The identifier is only ever
- * observable in the diagnostic Clang emits while parsing.
- *
- * Two diagnostic families report this:
- *  - `err_unknown_typename` (+ `_suggest`): the declaration is unambiguous
- *    so Sema reports the unresolved type directly. Argument 0 is an `IdentifierInfo*`.
- *  - `err_undeclared_var_use` (+ `_suggest`): a *bare* local declaration
- *    is syntactically ambiguous, and Clang's heuristic guesses.
- *    Argument 0 here is a `DeclarationName`.
- * Both are matched by name only (`StdHeaders.hpp` lookup)
- *
- * Every other diagnostic is swallowed
+ * An unresolved type name causes Sema to drop the whole statement. Instead, we catch
+ * the diagnostic and record the identifier, checking it against our StdHeaders map
+ * so that we can include the necessary header if necessary.
  */
 class UnknownTypeDiagConsumer : public clang::DiagnosticConsumer {
 public:
   /**
    * @brief Constructs the consumer, binding the shared output set.
    *
-   * @param unresolvedTypeNames Populated with the spelled name of every
-   *        unresolved type identifier seen; read by AddStdIncludesConsumer
-   *        once parsing completes.
+   * @param unresolvedTypeNames Populated w/ every unresolved type identifier.
+   *        Read by AddStdIncludesConsumer.
    */
   explicit UnknownTypeDiagConsumer(std::shared_ptr<std::set<std::string>> unresolvedTypeNames);
 
   /**
-   * @brief Records the identifier of an unresolved-type diagnostic; ignores everything else.
+   * @brief Records the identifier of an unresolved-type diagnostic.
    *
    * @param DiagLevel Severity of the diagnostic (unused - matched by ID only).
    * @param Info      The diagnostic being reported, including its format arguments.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ FetchContent_MakeAvailable(googletest)
 add_executable(filter_tests
   common/ClangToolUtilsTest.cpp
   common/ConfigParserTest.cpp
+  common/IncludeIndexTest.cpp
   filter/CountingVisitorTest.cpp
   filter/FilterFunctionsConsumerTest.cpp
   filter/FiltererStageTest.cpp

--- a/tests/common/IncludeIndexTest.cpp
+++ b/tests/common/IncludeIndexTest.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 The ARG-V Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "IncludeIndex.hpp"
+
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+// Builds a temp tree under the gtest temp dir, torn down in the destructor,
+// so each test gets an isolated filesystem sandbox.
+class TempTree {
+public:
+  explicit TempTree(const std::string &name)
+      : root(std::filesystem::temp_directory_path() / ("include-index-test-" + name)) {
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+  }
+  ~TempTree() { std::filesystem::remove_all(root); }
+
+  void writeFile(const std::filesystem::path &relPath, const std::string &content) {
+    std::filesystem::path full = root / relPath;
+    std::filesystem::create_directories(full.parent_path());
+    std::ofstream(full) << content;
+  }
+
+  std::filesystem::path root;
+};
+
+} // namespace
+
+TEST(IncludeIndex, ResolvesHeaderInDifferentSubtree) {
+  TempTree tree("subtree");
+  tree.writeFile("include/nested/mytypes.h", "typedef struct { int x; } point_t;\n");
+  tree.writeFile("src/main.c", "#include \"nested/mytypes.h\"\nint use(point_t p) { return p.x; }\n");
+
+  HeaderIndex index(tree.root);
+  std::vector<std::string> dirs = collectLocalIncludeDirs(tree.root / "src/main.c", index);
+
+  ASSERT_EQ(dirs.size(), 1u);
+  EXPECT_EQ(std::filesystem::path(dirs[0]), tree.root / "include");
+}
+
+TEST(IncludeIndex, ResolvesBareBasenameSibling) {
+  TempTree tree("sibling");
+  tree.writeFile("src/foo.h", "int foo(void);\n");
+  tree.writeFile("src/main.c", "#include \"foo.h\"\nint main(void) { return foo(); }\n");
+
+  HeaderIndex index(tree.root);
+  std::vector<std::string> dirs = collectLocalIncludeDirs(tree.root / "src/main.c", index);
+
+  ASSERT_EQ(dirs.size(), 1u);
+  EXPECT_EQ(std::filesystem::path(dirs[0]), tree.root / "src");
+}
+
+TEST(IncludeIndex, DropsCandidateWhoseSubdirDoesNotMatch) {
+  TempTree tree("mismatch");
+  // A same-named header sitting under an unrelated subdirectory should not
+  // be treated as a match for an include spec naming a different subdir.
+  tree.writeFile("vendor/other/mytypes.h", "typedef int unrelated_t;\n");
+  tree.writeFile("src/main.c", "#include \"nested/mytypes.h\"\nint x;\n");
+
+  HeaderIndex index(tree.root);
+  std::vector<std::string> dirs = collectLocalIncludeDirs(tree.root / "src/main.c", index);
+
+  EXPECT_TRUE(dirs.empty());
+}
+
+TEST(IncludeIndex, NoLocalIncludesYieldsNoDirs) {
+  TempTree tree("none");
+  tree.writeFile("src/main.c", "#include <stdio.h>\nint main(void) { return 0; }\n");
+
+  HeaderIndex index(tree.root);
+  std::vector<std::string> dirs = collectLocalIncludeDirs(tree.root / "src/main.c", index);
+
+  EXPECT_TRUE(dirs.empty());
+}
+
+TEST(IncludeIndex, MissingRootLeavesIndexEmpty) {
+  HeaderIndex index(std::filesystem::path("/no/such/directory/at/all"));
+  EXPECT_EQ(index.find("foo.h"), nullptr);
+}

--- a/tests/transform/cases/std-includes-diagnosed-type.expected.c
+++ b/tests/transform/cases/std-includes-diagnosed-type.expected.c
@@ -1,0 +1,10 @@
+#include <sys/types.h>
+void set_mode(void) {
+  mode_t m = 0;
+  int x = 1;
+}
+
+int main(void) {
+  set_mode();
+  return 0;
+}

--- a/tests/transform/cases/std-includes-diagnosed-type.input.c
+++ b/tests/transform/cases/std-includes-diagnosed-type.input.c
@@ -1,0 +1,4 @@
+void set_mode(void) {
+  mode_t m = 0;
+  int x = 1;
+}


### PR DESCRIPTION
This PR does some of the initial work for allowing the tool to find transitive header definitions, as well as recover standard header types that might otherwise be lost.

`IncludeIndex.hpp` builds an index of header files so that when Clang can't resolve a quoted include against the including file's own directory automatically, we can still resolve our own path.

`UnknownTypeDiagConsumer.hpp/.cpp`recovers standard-library type names that never make it into the AST. When Sema hits a type it can't resolve (e.g. a bare mode_t m; with the defining header stripped), it drops the whole statement. This consumer intercepts the err_unknown_typename/err_undeclared_var_use diagnostics Sema emits instead, pulls the identifier out of the diagnostic text, and feeds it to AddStdIncludesConsumer so the right standard header can be re-included even though the type left no trace in the tree.