### PR TITLE
Feature/natsteven/multi threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ Users can run single stages if building from source.
 Config files use INI syntax. Any `*.config` file is accepted with the following
 keys. See `settings.config` for more info.
 
-- `[Complexity Requirements]` - per-function `min,max` thresholds: `ForLoops`, `WhileLoops`, `IfStmt`, `CallFunc`, `Param`
-- `[Feature Requirements]` - per-function gates: `require` | `forbid` | `ignore` (default): `Concurrency` and `FloatingPoint`
-- `[File Settings]` - `FileLoC`, `fileTimeoutSecs`, `keepCompilesOnly`, `debugLevel` (0–3)
+- `[Complexity Requirements]` - per-function `min,max` thresholds: `ForLoops`, `WhileLoops`, `IfStmt`, `CallFunc`, `Param`, `Operations`
+- `[Feature Requirements]` - per-function gates: `require` | `forbid` | `ignore` (default): `Concurrency`, `FloatingPoint`, `PointerOrArray`, `PointerDeref`, `MemAlloc`, `MemFree`
+- `[File Settings]` - `FileLoC`, `fileTimeoutSecs`, `nproc` (files processed concurrently per stage; 0 = auto, three quarters of detected cores), `keepCompilesOnly`, `debugLevel` (0–3)
+- `[Havoc Settings]` - bounds emitted as `__HAVOC_*` macros into each benchmark: `havocArgcMin`, `havocArgcMax`, `havocStrMax`, `havocBlockMax`
 - `[Stage Directories]` - `databaseDir`, `filterDir`, `transformDir`, `benchmarkDir`
 
 # Build

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ keys. See `settings.config` for more info.
 
 - `[Complexity Requirements]` - per-function `min,max` thresholds: `ForLoops`, `WhileLoops`, `IfStmt`, `CallFunc`, `Param`, `Operations`
 - `[Feature Requirements]` - per-function gates: `require` | `forbid` | `ignore` (default): `Concurrency`, `FloatingPoint`, `PointerOrArray`, `PointerDeref`, `MemAlloc`, `MemFree`
-- `[File Settings]` - `FileLoC`, `fileTimeoutSecs`, `nproc` (files processed concurrently per stage; 0 = auto, three quarters of detected cores), `keepCompilesOnly`, `debugLevel` (0–3)
+- `[File Settings]` - `FileLoC`, `fileTimeoutSecs`, `nproc` (files processed concurrently per stage; 0 = auto, three quarters of detected cores; higher values are capped at the core count), `keepCompilesOnly`, `debugLevel` (0–3)
 - `[Havoc Settings]` - bounds emitted as `__HAVOC_*` macros into each benchmark: `havocArgcMin`, `havocArgcMax`, `havocStrMax`, `havocBlockMax`
 - `[Stage Directories]` - `databaseDir`, `filterDir`, `transformDir`, `benchmarkDir`
 

--- a/settings.config
+++ b/settings.config
@@ -2,57 +2,39 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# ARG-V pipeline configuration
-# [Headers] are ignored. Parser just finds key = value pairs.
+# ARG-V pipeline configuration. Every setting is optional; the values shown
+# are the defaults.
 
-# Filter thresholds, applied per function (main is not exempt from
-# these). A function whose count falls outside `min,max` for any metric is
-# removed. Unset metrics default to 0,9999. Also accepts 'min' or ',max'
-#   ForLoops   - for-loop count
-#   WhileLoops - while-loop count
-#   IfStmt     - if-statement count
-#   CallFunc   - calls made by the function
-#   Param      - parameter count
+# Per-function thresholds as `min,max` (also accepts `min` or `,max`).
+# Metrics: ForLoops, WhileLoops, IfStmt, CallFunc, Param, Operations.
 [Complexity Requirements]
 ForLoops = 0,9999
 
-# Filter gates, applied per function: require | forbid | ignore (default).
-#   Concurrency   - uses a concurrency-related type/call (e.g. pthread_*)
-#   FloatingPoint - uses float/double anywhere (param, local, or return type)
+# Per-function gates: require | forbid | ignore.
+# Features: Concurrency, FloatingPoint, PointerOrArray, PointerDeref,
+# MemAlloc, MemFree.
 [Feature Requirements]
 Concurrency = forbid
 
-# Additional filter/file settings
-#   FileLoC           - pre-filter 'min,max'
-#   fileTimeoutSecs   - wall-clock budget per file for the transform stage
-#   keepCompilesOnly  - if true (default), verify discards benchmarks that
-#                        fail the post-transform compile check
-#   debugLevel        - 0 = silent (summary + real errors only), 1 = per-file
-#                        progress, 2 = per-function decisions, 3 = everything
 [File Settings]
-FileLoC=5,9999
-fileTimeoutSecs=60
-keepCompilesOnly=true
-debugLevel=1
+FileLoC=5,9999         # whole-file line count, min,max
+fileTimeoutSecs=60     # wall-clock per file, so raise it alongside nproc
+nproc=0                # concurrent files per stage; 0 = 3/4 of detected cores
+keepCompilesOnly=true  # discard benchmarks that fail the compile check
+debugLevel=1           # 0 silent, 1 per-file, 2 per-function, 3 everything
 
-# Bounds MainGenConsumer emits as __HAVOC_* macros into each transformed file
-# (ahead of its #include "argv_c_harness.h"), so a generated benchmark can be
-# retuned by hand without rerunning the pipeline. All must be non-negative.
-#   havocArgcMin/Max - range the synthesized main's argc is bounded to before
-#                       argv is built
-#   havocStrMax      - buffer size for a havocked C string; its nondet NUL
-#                       terminator lands strictly below this
-#   havocBlockMax    - byte size for a havocked opaque-pointer block
+# Emitted as __HAVOC_* macros into each benchmark, so one can be retuned by
+# hand without rerunning the pipeline. All must be non-negative.
 [Havoc Settings]
-havocArgcMin=1
+havocArgcMin=1     # range the synthesized main's argc is bounded to
 havocArgcMax=4
-havocStrMax=16
-havocBlockMax=128
+havocStrMax=16     # havocked C string buffer; its NUL lands strictly below
+havocBlockMax=128  # bytes in a havocked opaque-pointer block
 
-# Intermediate directories for each stage. Defaults are shown and unless
-# specified here, these directories are cleaned up after a run.
+# Uncomment to keep a stage's directory; otherwise intermediates are cleaned
+# up after a run.
 [Stage Directories]
-# databaseDir=repos # filter input
-# filterDir=repos-filtered # filter output / transform input
+# databaseDir=repos              # filter input
+# filterDir=repos-filtered       # filter output / transform input
 # transformDir=repos-transformed # transform output / verify input
-# benchmarkDir=repos-benchmarks # benchmark output including *.yml files
+# benchmarkDir=repos-benchmarks  # final benchmarks, including *.yml

--- a/settings.config
+++ b/settings.config
@@ -19,7 +19,8 @@ Concurrency = forbid
 [File Settings]
 FileLoC=5,9999         # whole-file line count, min,max
 fileTimeoutSecs=60     # wall-clock per file, so raise it alongside nproc
-nproc=0                # concurrent files per stage; 0 = 3/4 of detected cores
+nproc=0                # concurrent files per stage; 0 = 3/4 of detected cores,
+                       #   values above the core count are capped at it
 keepCompilesOnly=true  # discard benchmarks that fail the compile check
 debugLevel=1           # 0 silent, 1 per-file, 2 per-function, 3 everything
 

--- a/src/common/include/ConfigParser.hpp
+++ b/src/common/include/ConfigParser.hpp
@@ -224,6 +224,13 @@ inline PipelineConfig parsePipelineConfig(const std::string &configFile) {
                     << std::endl;
           level = std::clamp(level, 0, 3);
         }
+      } else if (key == "nproc") {
+        int &workers = config.fileSettings.at(key);
+        if (workers < 0) {
+          std::cerr << "Warning: 'nproc' expects a non-negative count (0 = auto) - ignoring value '"
+                    << value << "'" << std::endl;
+          workers = 0;
+        }
       }
     } else if (config.havoc.count(key)) {
       try {

--- a/src/common/include/ConfigParser.hpp
+++ b/src/common/include/ConfigParser.hpp
@@ -51,7 +51,7 @@ struct PipelineConfig {
   /** File-level integer settings (booleans are stored as 0/1). */
   std::map<std::string, int> fileSettings = {
       {"debugLevel", 0},       {"minFileLoC", 0},        {"maxFileLoC", 9999},
-      {"fileTimeoutSecs", 60}, {"keepCompilesOnly", 1},
+      {"fileTimeoutSecs", 60}, {"keepCompilesOnly", 1},  {"nproc", 0},
   };
 
   /**

--- a/src/common/include/WorkerPool.hpp
+++ b/src/common/include/WorkerPool.hpp
@@ -37,15 +37,17 @@ inline int resolveWorkerCount(int configuredNproc) {
  * @brief The per-file work a worker pool isolates, shared by every caller of
  * {@code runWorkerPool}.
  *
- * Mirrors what each stage's old FooFileIsolated hand-rolled: a child body
- * that does the real work and exits with its result, an in-process fallback
- * for when fork() itself fails, and cleanup for a child that got killed.
+ * Child exits with its result, has an in-process fallback
+ * for when fork() itself fails, and cleanup for any child that got killed.
  */
 struct IsolatedWork {
   /**
    * Runs in the forked child. Must not return: do the work, flush stdout
-   * and stderr (`_exit` skips C++ stream flushing), then `_exit(1)` on
-   * success or `_exit(0)` otherwise.
+   * and stderr (`_exit` skips C++ stream flushing), then `_exit(0)` on
+   * success or any nonzero code otherwise. Standard Unix convention,
+   * chosen deliberately: it means a stray `exit()`/`std::exit()` call deep
+   * in Clang/LLVM internals (or anywhere else in the call stack) defaults
+   * to being read as failure rather than silently counted as success
    */
   std::function<void(const std::filesystem::path &)> child;
 
@@ -71,11 +73,8 @@ struct WorkerPoolJob {
  * inside the child) as one block, tagged with its file, then deletes the log
  * file. A no-op if the child wrote nothing (e.g. debugLevel 0).
  *
- * Concurrent children share the pool's real stderr, so writing debugLog
- * output there directly would interleave mid-line across processes; each
- * child instead has its own fd 2 redirected to a private file (see the fork
- * site below), and only the parent - which nothing else is writing to
- * stderr concurrently with - prints the finished block.
+ * Each child has its own fd 2 redirected to a private file (see the fork
+ * site below), and only the parent prints the finished block.
  */
 inline void flushChildLog(const WorkerPoolJob &job) {
   std::ifstream in(job.logPath);
@@ -95,17 +94,12 @@ inline void flushChildLog(const WorkerPoolJob &job) {
 
 /**
  * @brief Runs {@code work} over every file in {@code files}, isolating each
- * in its own forked child the way the old per-stage FooFileIsolated did, but
- * running up to {@code workers} children concurrently instead of one at a
- * time.
+ * in its own forked child running up to {@code workers} children concurrently.
  *
  * Each file gets its own wall-clock budget of {@code timeoutSecs} starting
- * from when its child is forked, independent of how long its pool-mates
- * take. Each child's debugLog output is buffered to a private file (see
- * {@code flushChildLog}) and printed as one block once the child is reaped,
- * so concurrent children's debug output never interleaves.
+ * from when its child is forked.
  *
- * @return count of files whose child exited reporting success (status 1).
+ * @return count of files whose child exited reporting success (status 0).
  */
 inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int workers,
                           int timeoutSecs, const IsolatedWork &work) {
@@ -142,15 +136,14 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
       }
       if (pid == 0) {
         // Redirect fd 2 (not just the C++ std::cerr stream) so debugLog
-        // calls anywhere in the child - including deep in the Clang chain -
-        // land in this child's own file instead of the shared stderr.
+        // calls anywhere in the child land in this child's own file instead of the shared stderr.
         int fd = open(logPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
         if (fd >= 0) {
           dup2(fd, STDERR_FILENO);
           close(fd);
         }
         work.child(file);
-        _exit(0); // safety net; work.child is expected to _exit itself
+        _exit(1); // safety net; work.child is expected to _exit itself
       }
       inFlight.push_back({pid, file, time(nullptr) + timeoutSecs, logPath});
     }
@@ -162,7 +155,13 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
       if (done == it->pid) {
         flushChildLog(*it);
         if (WIFEXITED(status)) {
-          produced += WEXITSTATUS(status) == 1 ? 1 : 0;
+          if (WEXITSTATUS(status) == 0) {
+            produced += 1;
+          } else {
+            work.debugLog(0, "failed (exit " + std::to_string(WEXITSTATUS(status)) +
+                                  "), skipping: " + it->file.string());
+            work.cleanupPartial(it->file);
+          }
         } else {
           work.debugLog(0, "crashed (signal " + std::to_string(WTERMSIG(status)) +
                                 "), skipping: " + it->file.string());

--- a/src/common/include/WorkerPool.hpp
+++ b/src/common/include/WorkerPool.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "DebugLog.hpp"
-
 #include <algorithm>
 #include <cerrno>
 #include <csignal>
@@ -25,17 +23,27 @@
 
 /**
  * @brief Resolves the {@code nproc} config setting to an actual worker count:
- * the configured value if positive, else three quarters of the detected cores
- * (floored at 1).
+ * the configured value if positive, capped at the detected core count, else
+ * three quarters of the detected cores (floored at 1).
  *
  * Auto-sizing leaves headroom deliberately: each worker holds a full Clang AST,
  * and each file's {@code timeoutSecs} budget is wall-clock, so contention for
  * cores pushes slow files past it and makes benchmark yield machine-dependent.
  */
 inline int resolveWorkerCount(int configuredNproc) {
-  if (configuredNproc > 0)
-    return configuredNproc;
   unsigned hw = std::thread::hardware_concurrency();
+  if (configuredNproc > 0) {
+    // Oversubscribing is clamped rather than honoured: each worker holds a
+    // full Clang AST, and children the OOM killer takes are reported as
+    // crashes whose output is discarded - a yield drop that reads as a tool
+    // bug rather than a config mistake.
+    if (hw > 0 && configuredNproc > static_cast<int>(hw)) {
+      std::cerr << "Warning: 'nproc' (" << configuredNproc << ") exceeds the " << hw
+                << " detected cores - using " << hw << std::endl;
+      return static_cast<int>(hw);
+    }
+    return configuredNproc;
+  }
   if (hw == 0)
     return 1;
   return static_cast<int>(std::max(1u, hw * 3 / 4));
@@ -64,9 +72,10 @@ struct WorkerPoolResult {
  */
 struct IsolatedWork {
   /**
-   * Runs in the forked child. Must not return: do the work, flush stdout and
-   * stderr (`_exit` skips C++ stream flushing), then `_exit(kProducedExit)`
-   * or `_exit(kDeclinedExit)`.
+   * Runs in the forked child. Must not return: do the work, remove any residue
+   * of its own it does not intend to keep, flush stdout and stderr (`_exit`
+   * skips C++ stream flushing), then `_exit(kProducedExit)` or
+   * `_exit(kDeclinedExit)`.
    */
   std::function<void(const std::filesystem::path &)> child;
 
@@ -76,7 +85,11 @@ struct IsolatedWork {
    */
   std::function<bool(const std::filesystem::path &)> runInProcess;
 
-  /** Removes any output a killed/crashed/timed-out child left behind. */
+  /**
+   * Removes the output of a child that died before it could tidy up after
+   * itself - killed, crashed, or timed out. Never called for a child that
+   * exited under its own control, which owns its own residue.
+   */
   std::function<void(const std::filesystem::path &)> cleanupPartial;
 
   /** (debugLevel, message) - routed to each stage's own debugLog. */
@@ -132,16 +145,19 @@ inline WorkerPoolResult runWorkerPool(const std::vector<std::filesystem::path> &
       std::filesystem::temp_directory_path(ec) / ("argv-c-pool-" + std::to_string(getpid()));
   if (ec)
     logDir = std::filesystem::path(".") / ("argv-c-pool-" + std::to_string(getpid()));
-  std::filesystem::create_directories(logDir);
+  // Losing the log dir only costs per-child stderr capture, so degrade to
+  // unredirected stderr rather than throwing out of the whole run.
+  std::filesystem::create_directories(logDir, ec);
 
   std::vector<WorkerPoolJob> inFlight;
   size_t next = 0;
   WorkerPoolResult result;
 
-  // Only readable at level 0: debugLog writes to stderr and would break up the
-  // carriage-returned line. The flush also keeps stdout empty at every fork
-  // below - an inherited dirty buffer gets flushed again by every child.
-  bool showProgress = globalDebugLevel() == 0 && !files.empty();
+  // Above level 0 the carriage-returned line is interleaved with debugLog's
+  // stderr output rather than updating in place. The flush also keeps stdout
+  // empty at every fork below - an inherited dirty buffer gets flushed again
+  // by every child.
+  bool showProgress = !files.empty();
   auto reportProgress = [&]() {
     if (showProgress)
       std::cout << "\r[" << work.label << "] " << (result.produced + result.declined + result.failed)
@@ -196,10 +212,11 @@ inline WorkerPoolResult runWorkerPool(const std::vector<std::filesystem::path> &
         if (WIFEXITED(status) && WEXITSTATUS(status) == kProducedExit) {
           result.produced++;
         } else if (WIFEXITED(status) && WEXITSTATUS(status) == kDeclinedExit) {
-          // Above level 0, so a run that declines most of its input stays quiet.
+          // No cleanup: the child exited under its own control, so whatever it
+          // left on disk it meant to leave. Above level 0, so a run that
+          // declines most of its input stays quiet.
           result.declined++;
           work.debugLog(1, "no output: " + it->file.string());
-          work.cleanupPartial(it->file);
         } else if (WIFEXITED(status)) {
           result.failed++;
           work.debugLog(0, "failed (exit " + std::to_string(WEXITSTATUS(status)) +

--- a/src/common/include/WorkerPool.hpp
+++ b/src/common/include/WorkerPool.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "DebugLog.hpp"
+
 #include <algorithm>
 #include <cerrno>
 #include <csignal>
@@ -22,36 +24,56 @@
 #include <vector>
 
 /**
- * @brief Resolves the {@code nproc} config setting to an actual worker
- * count: the configured value if positive, else the detected hardware
- * concurrency (floored at 1 if detection fails).
+ * @brief Resolves the {@code nproc} config setting to an actual worker count:
+ * the configured value if positive, else three quarters of the detected cores
+ * (floored at 1).
+ *
+ * Auto-sizing leaves headroom deliberately: each worker holds a full Clang AST,
+ * and each file's {@code timeoutSecs} budget is wall-clock, so contention for
+ * cores pushes slow files past it and makes benchmark yield machine-dependent.
  */
 inline int resolveWorkerCount(int configuredNproc) {
   if (configuredNproc > 0)
     return configuredNproc;
   unsigned hw = std::thread::hardware_concurrency();
-  return static_cast<int>(std::max(1u, hw));
+  if (hw == 0)
+    return 1;
+  return static_cast<int>(std::max(1u, hw * 3 / 4));
 }
+
+/** Child exit code for "produced an output file". */
+inline constexpr int kProducedExit = 0;
+
+/**
+ * Child exit code for "ran fine, produced nothing" - a declined file, not an
+ * error. Deliberately not 1: any other code counts as a failure, so a stray
+ * `exit(1)` inside Clang/LLVM is reported rather than read as a decline.
+ */
+inline constexpr int kDeclinedExit = 2;
+
+/** Per-outcome file counts for one {@code runWorkerPool} call. */
+struct WorkerPoolResult {
+  int produced = 0; ///< Children that exited {@code kProducedExit}.
+  int declined = 0; ///< Children that exited {@code kDeclinedExit}.
+  int failed = 0;   ///< Crashed, timed out, or exited any other code.
+};
 
 /**
  * @brief The per-file work a worker pool isolates, shared by every caller of
  * {@code runWorkerPool}.
- *
- * Child exits with its result, has an in-process fallback
- * for when fork() itself fails, and cleanup for any child that got killed.
  */
 struct IsolatedWork {
   /**
-   * Runs in the forked child. Must not return: do the work, flush stdout
-   * and stderr (`_exit` skips C++ stream flushing), then `_exit(0)` on
-   * success or any nonzero code otherwise. Standard Unix convention,
-   * chosen deliberately: it means a stray `exit()`/`std::exit()` call deep
-   * in Clang/LLVM internals (or anywhere else in the call stack) defaults
-   * to being read as failure rather than silently counted as success
+   * Runs in the forked child. Must not return: do the work, flush stdout and
+   * stderr (`_exit` skips C++ stream flushing), then `_exit(kProducedExit)`
+   * or `_exit(kDeclinedExit)`.
    */
   std::function<void(const std::filesystem::path &)> child;
 
-  /** Fallback run synchronously in the parent when fork() itself fails. */
+  /**
+   * Fallback run synchronously in the parent when fork() itself fails.
+   * Returning false counts as a decline, not a failure.
+   */
   std::function<bool(const std::filesystem::path &)> runInProcess;
 
   /** Removes any output a killed/crashed/timed-out child left behind. */
@@ -59,22 +81,24 @@ struct IsolatedWork {
 
   /** (debugLevel, message) - routed to each stage's own debugLog. */
   std::function<void(int, const std::string &)> debugLog;
+
+  /** Stage name used to tag the pool's progress line, e.g. "filter". */
+  std::string label;
 };
 
+/** One forked child the pool is currently waiting on. */
 struct WorkerPoolJob {
   pid_t pid;
   std::filesystem::path file;
-  time_t deadline;
-  std::filesystem::path logPath;
+  time_t deadline;               ///< Absolute wall-clock time after which the child is killed.
+  std::filesystem::path logPath; ///< Private file this child's fd 2 is redirected to.
 };
 
 /**
- * @brief Prints a reaped child's buffered stderr (from debugLog calls made
- * inside the child) as one block, tagged with its file, then deletes the log
- * file. A no-op if the child wrote nothing (e.g. debugLevel 0).
+ * @brief Prints a reaped child's buffered stderr as one block tagged with its
+ * file, then deletes the log. A no-op if the child wrote nothing.
  *
- * Each child has its own fd 2 redirected to a private file (see the fork
- * site below), and only the parent prints the finished block.
+ * Only the parent ever prints, so concurrent children's logs never interleave.
  */
 inline void flushChildLog(const WorkerPoolJob &job) {
   std::ifstream in(job.logPath);
@@ -99,10 +123,10 @@ inline void flushChildLog(const WorkerPoolJob &job) {
  * Each file gets its own wall-clock budget of {@code timeoutSecs} starting
  * from when its child is forked.
  *
- * @return count of files whose child exited reporting success (status 0).
+ * @return per-outcome counts; see {@code WorkerPoolResult}.
  */
-inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int workers,
-                          int timeoutSecs, const IsolatedWork &work) {
+inline WorkerPoolResult runWorkerPool(const std::vector<std::filesystem::path> &files, int workers,
+                                      int timeoutSecs, const IsolatedWork &work) {
   std::error_code ec;
   std::filesystem::path logDir =
       std::filesystem::temp_directory_path(ec) / ("argv-c-pool-" + std::to_string(getpid()));
@@ -112,7 +136,18 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
 
   std::vector<WorkerPoolJob> inFlight;
   size_t next = 0;
-  int produced = 0;
+  WorkerPoolResult result;
+
+  // Only readable at level 0: debugLog writes to stderr and would break up the
+  // carriage-returned line. The flush also keeps stdout empty at every fork
+  // below - an inherited dirty buffer gets flushed again by every child.
+  bool showProgress = globalDebugLevel() == 0 && !files.empty();
+  auto reportProgress = [&]() {
+    if (showProgress)
+      std::cout << "\r[" << work.label << "] " << (result.produced + result.declined + result.failed)
+                << "/" << files.size() << " processed" << std::flush;
+  };
+  reportProgress();
 
   auto killAndReap = [&](WorkerPoolJob &job, const char *reason) {
     int status = 0;
@@ -131,7 +166,11 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
       pid_t pid = fork();
       if (pid < 0) {
         work.debugLog(0, "fork failed, running in-process: " + file.string());
-        produced += work.runInProcess(file) ? 1 : 0;
+        if (work.runInProcess(file))
+          result.produced++;
+        else
+          result.declined++;
+        reportProgress();
         continue;
       }
       if (pid == 0) {
@@ -154,15 +193,20 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
       pid_t done = waitpid(it->pid, &status, WNOHANG);
       if (done == it->pid) {
         flushChildLog(*it);
-        if (WIFEXITED(status)) {
-          if (WEXITSTATUS(status) == 0) {
-            produced += 1;
-          } else {
-            work.debugLog(0, "failed (exit " + std::to_string(WEXITSTATUS(status)) +
-                                  "), skipping: " + it->file.string());
-            work.cleanupPartial(it->file);
-          }
+        if (WIFEXITED(status) && WEXITSTATUS(status) == kProducedExit) {
+          result.produced++;
+        } else if (WIFEXITED(status) && WEXITSTATUS(status) == kDeclinedExit) {
+          // Above level 0, so a run that declines most of its input stays quiet.
+          result.declined++;
+          work.debugLog(1, "no output: " + it->file.string());
+          work.cleanupPartial(it->file);
+        } else if (WIFEXITED(status)) {
+          result.failed++;
+          work.debugLog(0, "failed (exit " + std::to_string(WEXITSTATUS(status)) +
+                                "), skipping: " + it->file.string());
+          work.cleanupPartial(it->file);
         } else {
+          result.failed++;
           work.debugLog(0, "crashed (signal " + std::to_string(WTERMSIG(status)) +
                                 "), skipping: " + it->file.string());
           work.cleanupPartial(it->file);
@@ -171,16 +215,21 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
         reaped = true;
       } else if (done < 0 && errno != EINTR) {
         killAndReap(*it, "waitpid failed, killing");
+        result.failed++;
         it = inFlight.erase(it);
         reaped = true;
       } else if (time(nullptr) >= it->deadline) {
         killAndReap(*it, "Timeout, killing");
+        result.failed++;
         it = inFlight.erase(it);
         reaped = true;
       } else {
         ++it;
       }
     }
+
+    if (reaped)
+      reportProgress();
 
     // Nothing to reap and no free slot (or nothing left to submit): avoid a
     // busy-spin while children run.
@@ -190,6 +239,9 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
     }
   }
 
+  if (showProgress)
+    std::cout << std::endl;
+
   std::filesystem::remove_all(logDir, ec);
-  return produced;
+  return result;
 }

--- a/src/common/include/WorkerPool.hpp
+++ b/src/common/include/WorkerPool.hpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 The ARG-V Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+#include <ctime>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+/**
+ * @brief Resolves the {@code nproc} config setting to an actual worker
+ * count: the configured value if positive, else the detected hardware
+ * concurrency (floored at 1 if detection fails).
+ */
+inline int resolveWorkerCount(int configuredNproc) {
+  if (configuredNproc > 0)
+    return configuredNproc;
+  unsigned hw = std::thread::hardware_concurrency();
+  return static_cast<int>(std::max(1u, hw));
+}
+
+/**
+ * @brief The per-file work a worker pool isolates, shared by every caller of
+ * {@code runWorkerPool}.
+ *
+ * Mirrors what each stage's old FooFileIsolated hand-rolled: a child body
+ * that does the real work and exits with its result, an in-process fallback
+ * for when fork() itself fails, and cleanup for a child that got killed.
+ */
+struct IsolatedWork {
+  /**
+   * Runs in the forked child. Must not return: do the work, flush stdout
+   * and stderr (`_exit` skips C++ stream flushing), then `_exit(1)` on
+   * success or `_exit(0)` otherwise.
+   */
+  std::function<void(const std::filesystem::path &)> child;
+
+  /** Fallback run synchronously in the parent when fork() itself fails. */
+  std::function<bool(const std::filesystem::path &)> runInProcess;
+
+  /** Removes any output a killed/crashed/timed-out child left behind. */
+  std::function<void(const std::filesystem::path &)> cleanupPartial;
+
+  /** (debugLevel, message) - routed to each stage's own debugLog. */
+  std::function<void(int, const std::string &)> debugLog;
+};
+
+struct WorkerPoolJob {
+  pid_t pid;
+  std::filesystem::path file;
+  time_t deadline;
+};
+
+/**
+ * @brief Runs {@code work} over every file in {@code files}, isolating each
+ * in its own forked child the way the old per-stage FooFileIsolated did, but
+ * running up to {@code workers} children concurrently instead of one at a
+ * time.
+ *
+ * Each file gets its own wall-clock budget of {@code timeoutSecs} starting
+ * from when its child is forked, independent of how long its pool-mates
+ * take.
+ *
+ * @return count of files whose child exited reporting success (status 1).
+ */
+inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int workers,
+                          int timeoutSecs, const IsolatedWork &work) {
+  std::vector<WorkerPoolJob> inFlight;
+  size_t next = 0;
+  int produced = 0;
+
+  auto killAndReap = [&](WorkerPoolJob &job, const char *reason) {
+    int status = 0;
+    kill(job.pid, SIGKILL);
+    waitpid(job.pid, &status, 0);
+    work.debugLog(0, std::string(reason) + ": " + job.file.string());
+    work.cleanupPartial(job.file);
+  };
+
+  while (next < files.size() || !inFlight.empty()) {
+    while (static_cast<int>(inFlight.size()) < workers && next < files.size()) {
+      const std::filesystem::path &file = files[next++];
+      pid_t pid = fork();
+      if (pid < 0) {
+        work.debugLog(0, "fork failed, running in-process: " + file.string());
+        produced += work.runInProcess(file) ? 1 : 0;
+        continue;
+      }
+      if (pid == 0) {
+        work.child(file);
+        _exit(0); // safety net; work.child is expected to _exit itself
+      }
+      inFlight.push_back({pid, file, time(nullptr) + timeoutSecs});
+    }
+
+    bool reaped = false;
+    for (auto it = inFlight.begin(); it != inFlight.end();) {
+      int status = 0;
+      pid_t done = waitpid(it->pid, &status, WNOHANG);
+      if (done == it->pid) {
+        if (WIFEXITED(status)) {
+          produced += WEXITSTATUS(status) == 1 ? 1 : 0;
+        } else {
+          work.debugLog(0, "crashed (signal " + std::to_string(WTERMSIG(status)) +
+                                "), skipping: " + it->file.string());
+          work.cleanupPartial(it->file);
+        }
+        it = inFlight.erase(it);
+        reaped = true;
+      } else if (done < 0 && errno != EINTR) {
+        killAndReap(*it, "waitpid failed, killing");
+        it = inFlight.erase(it);
+        reaped = true;
+      } else if (time(nullptr) >= it->deadline) {
+        killAndReap(*it, "Timeout, killing");
+        it = inFlight.erase(it);
+        reaped = true;
+      } else {
+        ++it;
+      }
+    }
+
+    // Nothing to reap and no free slot (or nothing left to submit): avoid a
+    // busy-spin while children run.
+    if (!reaped && !inFlight.empty()) {
+      struct timespec nap = {0, 20 * 1000 * 1000}; // 20ms
+      nanosleep(&nap, nullptr);
+    }
+  }
+  return produced;
+}

--- a/src/common/include/WorkerPool.hpp
+++ b/src/common/include/WorkerPool.hpp
@@ -9,8 +9,12 @@
 #include <csignal>
 #include <cstring>
 #include <ctime>
+#include <fcntl.h>
 #include <filesystem>
+#include <fstream>
 #include <functional>
+#include <iostream>
+#include <sstream>
 #include <string>
 #include <sys/wait.h>
 #include <thread>
@@ -59,7 +63,35 @@ struct WorkerPoolJob {
   pid_t pid;
   std::filesystem::path file;
   time_t deadline;
+  std::filesystem::path logPath;
 };
+
+/**
+ * @brief Prints a reaped child's buffered stderr (from debugLog calls made
+ * inside the child) as one block, tagged with its file, then deletes the log
+ * file. A no-op if the child wrote nothing (e.g. debugLevel 0).
+ *
+ * Concurrent children share the pool's real stderr, so writing debugLog
+ * output there directly would interleave mid-line across processes; each
+ * child instead has its own fd 2 redirected to a private file (see the fork
+ * site below), and only the parent - which nothing else is writing to
+ * stderr concurrently with - prints the finished block.
+ */
+inline void flushChildLog(const WorkerPoolJob &job) {
+  std::ifstream in(job.logPath);
+  if (in) {
+    std::ostringstream buf;
+    buf << in.rdbuf();
+    std::string content = buf.str();
+    if (!content.empty()) {
+      std::cerr << "----- " << job.file.string() << " -----\n" << content;
+      if (content.back() != '\n')
+        std::cerr << '\n';
+    }
+  }
+  std::error_code ec;
+  std::filesystem::remove(job.logPath, ec);
+}
 
 /**
  * @brief Runs {@code work} over every file in {@code files}, isolating each
@@ -69,12 +101,21 @@ struct WorkerPoolJob {
  *
  * Each file gets its own wall-clock budget of {@code timeoutSecs} starting
  * from when its child is forked, independent of how long its pool-mates
- * take.
+ * take. Each child's debugLog output is buffered to a private file (see
+ * {@code flushChildLog}) and printed as one block once the child is reaped,
+ * so concurrent children's debug output never interleaves.
  *
  * @return count of files whose child exited reporting success (status 1).
  */
 inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int workers,
                           int timeoutSecs, const IsolatedWork &work) {
+  std::error_code ec;
+  std::filesystem::path logDir =
+      std::filesystem::temp_directory_path(ec) / ("argv-c-pool-" + std::to_string(getpid()));
+  if (ec)
+    logDir = std::filesystem::path(".") / ("argv-c-pool-" + std::to_string(getpid()));
+  std::filesystem::create_directories(logDir);
+
   std::vector<WorkerPoolJob> inFlight;
   size_t next = 0;
   int produced = 0;
@@ -83,13 +124,16 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
     int status = 0;
     kill(job.pid, SIGKILL);
     waitpid(job.pid, &status, 0);
+    flushChildLog(job);
     work.debugLog(0, std::string(reason) + ": " + job.file.string());
     work.cleanupPartial(job.file);
   };
 
   while (next < files.size() || !inFlight.empty()) {
     while (static_cast<int>(inFlight.size()) < workers && next < files.size()) {
+      size_t idx = next;
       const std::filesystem::path &file = files[next++];
+      std::filesystem::path logPath = logDir / (std::to_string(idx) + ".log");
       pid_t pid = fork();
       if (pid < 0) {
         work.debugLog(0, "fork failed, running in-process: " + file.string());
@@ -97,10 +141,18 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
         continue;
       }
       if (pid == 0) {
+        // Redirect fd 2 (not just the C++ std::cerr stream) so debugLog
+        // calls anywhere in the child - including deep in the Clang chain -
+        // land in this child's own file instead of the shared stderr.
+        int fd = open(logPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (fd >= 0) {
+          dup2(fd, STDERR_FILENO);
+          close(fd);
+        }
         work.child(file);
         _exit(0); // safety net; work.child is expected to _exit itself
       }
-      inFlight.push_back({pid, file, time(nullptr) + timeoutSecs});
+      inFlight.push_back({pid, file, time(nullptr) + timeoutSecs, logPath});
     }
 
     bool reaped = false;
@@ -108,6 +160,7 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
       int status = 0;
       pid_t done = waitpid(it->pid, &status, WNOHANG);
       if (done == it->pid) {
+        flushChildLog(*it);
         if (WIFEXITED(status)) {
           produced += WEXITSTATUS(status) == 1 ? 1 : 0;
         } else {
@@ -137,5 +190,7 @@ inline int runWorkerPool(const std::vector<std::filesystem::path> &files, int wo
       nanosleep(&nap, nullptr);
     }
   }
+
+  std::filesystem::remove_all(logDir, ec);
   return produced;
 }

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -7,23 +7,19 @@
 #include "ClangToolUtils.hpp"
 #include "CliArgs.hpp"
 #include "DebugLog.hpp"
+#include "WorkerPool.hpp"
 
 #include <clang/AST/Type.h>
 #include <clang/Lex/Preprocessor.h>
 #include <clang/Rewrite/Core/Rewriter.h>
 #include <clang/Tooling/CommonOptionsParser.h>
 #include <clang/Tooling/Tooling.h>
-#include <cerrno>
-#include <csignal>
-#include <cstring>
-#include <ctime>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <llvm/Support/Error.h>
 #include <llvm/Support/raw_ostream.h>
 #include <string>
-#include <sys/wait.h>
 #include <unistd.h>
 
 const std::string defaultDatabaseDir = "repos";
@@ -33,6 +29,7 @@ const int defaultFileTimeoutSecs = 60;
 Filterer::Filterer(std::string configFile, std::string inputPath) {
   configuration.databaseDir = defaultDatabaseDir;
   configuration.fileTimeoutSecs = defaultFileTimeoutSecs;
+  configuration.nproc = 0;
   if (!configFile.empty())
     parseConfigFile(configFile);
   if (configuration.filterDir.empty())
@@ -53,6 +50,7 @@ void Filterer::parseConfigFile(std::string configFile) {
 
   globalDebugLevel() = config.fileSettings.at("debugLevel");
   configuration.fileTimeoutSecs = config.fileSettings.at("fileTimeoutSecs");
+  configuration.nproc = config.fileSettings.at("nproc");
 
   if (globalDebugLevel() >= 1) {
     std::string dump = "[filter] loaded config: " + configFile;
@@ -175,52 +173,6 @@ bool Filterer::filterFile(std::filesystem::path oldPath) {
   return true;
 }
 
-int Filterer::filterFileIsolated(std::filesystem::path oldPath) {
-  pid_t pid = fork();
-  if (pid < 0) {
-    debugLog(0, "fork failed, filtering in-process: " + oldPath.string());
-    return filterFile(oldPath) ? 1 : 0;
-  }
-
-  if (pid == 0) {
-    int produced = filterFile(oldPath) ? 1 : 0;
-    std::cout.flush();
-    std::cerr.flush();
-    _exit(produced);
-  }
-
-  time_t deadline = time(nullptr) + configuration.fileTimeoutSecs;
-  int status = 0;
-  while (true) {
-    pid_t done = waitpid(pid, &status, WNOHANG);
-    if (done == pid)
-      break;
-    if (done < 0 && errno != EINTR) {
-      debugLog(0, "waitpid failed for " + oldPath.string() + ", killing: " + strerror(errno));
-      kill(pid, SIGKILL);
-      waitpid(pid, &status, 0);
-      cleanupPartialOutput(oldPath);
-      return 0;
-    }
-    if (time(nullptr) >= deadline) {
-      debugLog(0, "Timeout, killing filter of: " + oldPath.string());
-      kill(pid, SIGKILL);
-      waitpid(pid, &status, 0);
-      cleanupPartialOutput(oldPath);
-      return 0;
-    }
-    struct timespec nap = {0, 20 * 1000 * 1000}; // 20ms
-    nanosleep(&nap, nullptr);
-  }
-
-  if (WIFEXITED(status))
-    return WEXITSTATUS(status) == 1 ? 1 : 0;
-  debugLog(0, "Filter crashed (signal " + std::to_string(WTERMSIG(status)) + "), skipping: " +
-                  oldPath.string());
-  cleanupPartialOutput(oldPath);
-  return 0;
-}
-
 void Filterer::cleanupPartialOutput(std::filesystem::path oldPath) {
   std::error_code ec;
   std::filesystem::remove(outputPath(oldPath), ec);
@@ -240,20 +192,32 @@ int Filterer::run() {
   headerIndex.emplace(configuration.databaseDir);
 
   int passed = 0;
-  int produced = 0;
-  int i = 0;
+  std::vector<std::filesystem::path> toProcess;
   for (const std::string &fileName : filesToFilter) {
-    std::cout << "\r[filter] " << ++i << "/" << filesFound << std::flush;
     debugLog(1, "[filter] file: " + fileName);
     if (!checkPotentialFile(fileName))
       continue;
     passed++;
-
-    std::filesystem::path oldPath(fileName);
-    produced += filterFileIsolated(oldPath);
+    toProcess.emplace_back(fileName);
   }
-  if (filesFound > 0)
-    std::cout << std::endl;
+
+  int workers = resolveWorkerCount(configuration.nproc);
+  debugLog(1, "[filter] worker pool size: " + std::to_string(workers));
+
+  IsolatedWork work;
+  work.child = [this](const std::filesystem::path &p) {
+    int produced = filterFile(p) ? 1 : 0;
+    std::cout.flush();
+    std::cerr.flush();
+    _exit(produced);
+  };
+  work.runInProcess = [this](const std::filesystem::path &p) { return filterFile(p); };
+  work.cleanupPartial = [this](const std::filesystem::path &p) { cleanupPartialOutput(p); };
+  work.debugLog = [](int level, const std::string &msg) { debugLog(level, "[filter] " + msg); };
+
+  std::cout << "[filter] processing " << toProcess.size() << " file(s) with " << workers
+            << " worker(s)" << std::endl;
+  int produced = runWorkerPool(toProcess, workers, configuration.fileTimeoutSecs, work);
 
   std::cout << "\n=== Filter summary ===\n"
             << "  Files found:            " << filesFound << "\n"

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -168,14 +168,21 @@ bool Filterer::filterFile(std::filesystem::path oldPath) {
   output.close();
   if (!ran) {
     debugLog(1, "[filter] clang tool failed on: " + oldPath.string());
+    // The stream above already created/truncated newPath.
+    cleanupPartialOutput(oldPath);
     return false;
   }
   return true;
 }
 
 void Filterer::cleanupPartialOutput(std::filesystem::path oldPath) {
+  std::filesystem::path newPath = outputPath(oldPath);
+  // The same guard filterFile applies before writing: when databaseDir and
+  // filterDir resolve to one directory, the "partial output" is the input.
+  if (std::filesystem::weakly_canonical(oldPath) == std::filesystem::weakly_canonical(newPath))
+    return;
   std::error_code ec;
-  std::filesystem::remove(outputPath(oldPath), ec);
+  std::filesystem::remove(newPath, ec);
 }
 
 int Filterer::run() {

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -209,21 +209,23 @@ int Filterer::run() {
     bool produced = filterFile(p);
     std::cout.flush();
     std::cerr.flush();
-    _exit(produced ? 0 : 1);
+    _exit(produced ? kProducedExit : kDeclinedExit);
   };
   work.runInProcess = [this](const std::filesystem::path &p) { return filterFile(p); };
   work.cleanupPartial = [this](const std::filesystem::path &p) { cleanupPartialOutput(p); };
   work.debugLog = [](int level, const std::string &msg) { debugLog(level, "[filter] " + msg); };
+  work.label = "filter";
 
   std::cout << "[filter] processing " << toProcess.size() << " file(s) with " << workers
             << " worker(s)" << std::endl;
-  int produced = runWorkerPool(toProcess, workers, configuration.fileTimeoutSecs, work);
+  WorkerPoolResult result = runWorkerPool(toProcess, workers, configuration.fileTimeoutSecs, work);
 
   std::cout << "\n=== Filter summary ===\n"
             << "  Files found:            " << filesFound << "\n"
             << "  Passed pre-filter:      " << passed << "\n"
             << "  Skipped (pre-filter):   " << (filesFound - passed) << "\n"
-            << "  Files filtered:         " << produced << "\n"
-            << "  Discarded/failed:       " << (passed - produced) << std::endl;
-  return produced;
+            << "  Files filtered:         " << result.produced << "\n"
+            << "  Declined (no output):   " << result.declined << "\n"
+            << "  Failed:                 " << result.failed << std::endl;
+  return result.produced;
 }

--- a/src/filter/Filterer.cpp
+++ b/src/filter/Filterer.cpp
@@ -206,10 +206,10 @@ int Filterer::run() {
 
   IsolatedWork work;
   work.child = [this](const std::filesystem::path &p) {
-    int produced = filterFile(p) ? 1 : 0;
+    bool produced = filterFile(p);
     std::cout.flush();
     std::cerr.flush();
-    _exit(produced);
+    _exit(produced ? 0 : 1);
   };
   work.runInProcess = [this](const std::filesystem::path &p) { return filterFile(p); };
   work.cleanupPartial = [this](const std::filesystem::path &p) { cleanupPartialOutput(p); };

--- a/src/filter/include/Filterer.hpp
+++ b/src/filter/include/Filterer.hpp
@@ -23,7 +23,7 @@ struct filterConfigs {
   std::string databaseDir; ///< Directory containing the source repos to filter
   std::string filterDir;   ///< Output directory for files that pass the filter
   int fileTimeoutSecs;     ///< Wall-clock budget per file for the isolated filter child.
-  int nproc;               ///< Worker pool size (0 = default to hardware concurrency).
+  int nproc;               ///< Worker pool size (0 = auto, three quarters of detected cores).
 };
 
 /**

--- a/src/filter/include/Filterer.hpp
+++ b/src/filter/include/Filterer.hpp
@@ -23,6 +23,7 @@ struct filterConfigs {
   std::string databaseDir; ///< Directory containing the source repos to filter
   std::string filterDir;   ///< Output directory for files that pass the filter
   int fileTimeoutSecs;     ///< Wall-clock budget per file for the isolated filter child.
+  int nproc;               ///< Worker pool size (0 = default to hardware concurrency).
 };
 
 /**
@@ -83,14 +84,6 @@ public:
    * @return true if a filtered .c was produced.
    */
   bool filterFile(std::filesystem::path oldPath);
-
-  /**
-   * @brief Runs {@code filterFile} in a forked child for crash isolation.
-   *
-   * @param oldPath Path to the source .c file to filter.
-   * @return 1 if a filtered file was produced, 0 otherwise.
-   */
-  int filterFileIsolated(std::filesystem::path oldPath);
 
   /**
    * @brief Removes any .c a crashed or timed-out child left behind.

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -99,8 +99,6 @@ bool Transformer::transformFile(std::filesystem::path path) {
   return true;
 }
 
-// Remove any .c a crashed or timed-out child left half-written, so
-// downstream steps never see a partial file.
 void Transformer::cleanupPartialOutput(std::filesystem::path path) {
   std::error_code ec;
   std::filesystem::remove(flattenedOutputPath(path), ec);
@@ -129,7 +127,7 @@ void Transformer::collectCFiles(std::filesystem::path path, std::vector<std::fil
   debugLog(3, "[transform] ignored: " + path.filename().string());
 }
 
-int Transformer::transformAll(std::filesystem::path path) {
+WorkerPoolResult Transformer::transformAll(std::filesystem::path path) {
   std::vector<std::filesystem::path> files;
   collectCFiles(path, files);
   _totalProcessed = static_cast<int>(files.size());
@@ -144,11 +142,12 @@ int Transformer::transformAll(std::filesystem::path path) {
     bool produced = transformFile(p);
     std::cout.flush();
     std::cerr.flush();
-    _exit(produced ? 0 : 1);
+    _exit(produced ? kProducedExit : kDeclinedExit);
   };
   work.runInProcess = [this](const std::filesystem::path &p) { return transformFile(p); };
   work.cleanupPartial = [this](const std::filesystem::path &p) { cleanupPartialOutput(p); };
   work.debugLog = [](int level, const std::string &msg) { debugLog(level, "[transform] " + msg); };
+  work.label = "transform";
 
   return runWorkerPool(files, workers, configuration.fileTimeoutSecs, work);
 }
@@ -179,11 +178,11 @@ int Transformer::run() {
   // Built before any fork; each child inherits the index as-is.
   headerIndex.emplace(configuration.databaseDir);
 
-  int result = transformAll(path);
-  int discarded = _totalProcessed - result;
+  WorkerPoolResult result = transformAll(path);
   std::cout << "\n=== Transform summary ===\n"
             << "  Files processed:        " << _totalProcessed << "\n"
-            << "  Files transformed:      " << result << "\n"
-            << "  Discarded/failed:       " << discarded << std::endl;
-  return result;
+            << "  Files transformed:      " << result.produced << "\n"
+            << "  Declined (no output):   " << result.declined << "\n"
+            << "  Failed:                 " << result.failed << std::endl;
+  return result.produced;
 }

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -8,11 +8,8 @@
 #include "ConfigParser.hpp"
 #include "DebugLog.hpp"
 #include "IncludeIndex.hpp"
+#include "WorkerPool.hpp"
 
-#include <cerrno>
-#include <csignal>
-#include <cstring>
-#include <ctime>
 #include <filesystem>
 #include <iostream>
 #include <llvm/ADT/StringRef.h>
@@ -20,7 +17,6 @@
 #include <string>
 #include <system_error>
 #include <vector>
-#include <sys/wait.h>
 #include <unistd.h>
 
 const int defaultDebugLevel = 0;
@@ -33,6 +29,7 @@ Transformer::Transformer(std::string configFile, std::string inputPath) : config
   configuration.debugLevel = defaultDebugLevel;
   configuration.filterDir = defaultFilterDir;
   configuration.fileTimeoutSecs = defaultFileTimeoutSecs;
+  configuration.nproc = 0;
   if (!configFile.empty())
     parseConfig(configFile);
   if (configuration.transformDir.empty())
@@ -64,7 +61,7 @@ std::filesystem::path Transformer::flattenedOutputPath(std::filesystem::path pat
 }
 
 bool Transformer::transformFile(std::filesystem::path path) {
-  debugLog(1, "[transform] file " + std::to_string(_totalProcessed) + ": " + path.string());
+  debugLog(1, "[transform] file: " + path.string());
   if (!std::filesystem::exists(path)) {
     debugLog(1, "[transform] path does not exist: " + path.string());
     return false;
@@ -102,90 +99,65 @@ bool Transformer::transformFile(std::filesystem::path path) {
   return true;
 }
 
-int Transformer::transformFileIsolated(std::filesystem::path path) {
-  _totalProcessed++;
-  if (globalDebugLevel() == 0)
-    std::cout << "\r[transform] " << _totalProcessed << " processed" << std::flush;
-  pid_t pid = fork();
-  if (pid < 0) {
-    debugLog(0, "fork failed, transforming in-process: " + path.string());
-    return transformFile(path) ? 1 : 0;
-  }
-
-  if (pid == 0) {
-    // Child: _exit skips C++ stream flushing, so flush explicitly first.
-    int produced = transformFile(path) ? 1 : 0;
-    std::cout.flush();
-    std::cerr.flush();
-    _exit(produced);
-  }
-
-  // Parent: poll, killing the child if it overruns the budget.
-  time_t deadline = time(nullptr) + configuration.fileTimeoutSecs;
-  int status = 0;
-  while (true) {
-    pid_t done = waitpid(pid, &status, WNOHANG);
-    if (done == pid)
-      break;
-    if (done < 0 && errno != EINTR) {
-      debugLog(0, "waitpid failed for " + path.string() + ", killing: " + strerror(errno));
-      kill(pid, SIGKILL);
-      waitpid(pid, &status, 0);
-      cleanupPartialOutput(path);
-      return 0;
-    }
-    if (time(nullptr) >= deadline) {
-      debugLog(0, "Timeout, killing transform of: " + path.string());
-      kill(pid, SIGKILL);
-      waitpid(pid, &status, 0);
-      cleanupPartialOutput(path);
-      return 0;
-    }
-    struct timespec nap = {0, 20 * 1000 * 1000}; // 20ms
-    nanosleep(&nap, nullptr);
-  }
-
-  if (WIFEXITED(status))
-    return WEXITSTATUS(status) == 1 ? 1 : 0;
-  // WIFSIGNALED: harnessIsEmpty never ran, so a partial .c may be left behind.
-  debugLog(0, "Transform crashed (signal " + std::to_string(WTERMSIG(status)) + "), skipping: " +
-                  path.string());
-  cleanupPartialOutput(path);
-  return 0;
-}
-
+// Remove any .c a crashed or timed-out child left half-written, so
+// downstream steps never see a partial file.
 void Transformer::cleanupPartialOutput(std::filesystem::path path) {
   std::error_code ec;
   std::filesystem::remove(flattenedOutputPath(path), ec);
 }
 
-int Transformer::transformAll(std::filesystem::path path) {
+void Transformer::collectCFiles(std::filesystem::path path, std::vector<std::filesystem::path> &files) {
   if (!std::filesystem::exists(path)) {
     debugLog(1, "[transform] path does not exist: " + path.string());
-    return 0;
+    return;
   }
   if (std::filesystem::is_directory(path)) {
-    int successes = 0;
     for (const std::filesystem::directory_entry &entry :
          std::filesystem::directory_iterator(path)) {
-      successes += transformAll(entry.path());
+      collectCFiles(entry.path(), files);
     }
-    return successes;
+    return;
   }
   if (std::filesystem::is_regular_file(path)) {
-    if (path.extension() == ".c")
-      return transformFileIsolated(path);
-    debugLog(3, "[transform] skipped (not .c): " + path.filename().string());
-    return 0;
+    if (path.extension() == ".c") {
+      files.push_back(path);
+    } else {
+      debugLog(3, "[transform] skipped (not .c): " + path.filename().string());
+    }
+    return;
   }
   debugLog(3, "[transform] ignored: " + path.filename().string());
-  return 0;
+}
+
+int Transformer::transformAll(std::filesystem::path path) {
+  std::vector<std::filesystem::path> files;
+  collectCFiles(path, files);
+  _totalProcessed = static_cast<int>(files.size());
+
+  int workers = resolveWorkerCount(configuration.nproc);
+  debugLog(1, "[transform] worker pool size: " + std::to_string(workers));
+  std::cout << "[transform] processing " << files.size() << " file(s) with " << workers
+            << " worker(s)" << std::endl;
+
+  IsolatedWork work;
+  work.child = [this](const std::filesystem::path &p) {
+    int produced = transformFile(p) ? 1 : 0;
+    std::cout.flush();
+    std::cerr.flush();
+    _exit(produced);
+  };
+  work.runInProcess = [this](const std::filesystem::path &p) { return transformFile(p); };
+  work.cleanupPartial = [this](const std::filesystem::path &p) { cleanupPartialOutput(p); };
+  work.debugLog = [](int level, const std::string &msg) { debugLog(level, "[transform] " + msg); };
+
+  return runWorkerPool(files, workers, configuration.fileTimeoutSecs, work);
 }
 
 void Transformer::parseConfig(std::string configFile) {
   PipelineConfig config = parsePipelineConfig(configFile);
   configuration.debugLevel = config.fileSettings.at("debugLevel");
   configuration.fileTimeoutSecs = config.fileSettings.at("fileTimeoutSecs");
+  configuration.nproc = config.fileSettings.at("nproc");
   if (!config.transformDir.empty()) {
     configuration.transformDir = config.transformDir;
   }

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -141,10 +141,10 @@ int Transformer::transformAll(std::filesystem::path path) {
 
   IsolatedWork work;
   work.child = [this](const std::filesystem::path &p) {
-    int produced = transformFile(p) ? 1 : 0;
+    bool produced = transformFile(p);
     std::cout.flush();
     std::cerr.flush();
-    _exit(produced);
+    _exit(produced ? 0 : 1);
   };
   work.runInProcess = [this](const std::filesystem::path &p) { return transformFile(p); };
   work.cleanupPartial = [this](const std::filesystem::path &p) { cleanupPartialOutput(p); };

--- a/src/transform/Transformer.cpp
+++ b/src/transform/Transformer.cpp
@@ -87,21 +87,28 @@ bool Transformer::transformFile(std::filesystem::path path) {
   output.close();
   if (!ran) {
     debugLog(1, "[transform] clang tool failed on: " + path.string());
+    // The stream above already created/truncated srcPath.
+    cleanupPartialOutput(path);
     return false;
   }
 
   if (harnessIsEmpty(srcPath)) {
     debugLog(2, "[transform] discarded (harness empty, nothing havocked/harnessed): " +
                     srcPath.string());
-    std::filesystem::remove(srcPath);
+    cleanupPartialOutput(path);
     return false;
   }
   return true;
 }
 
 void Transformer::cleanupPartialOutput(std::filesystem::path path) {
+  std::filesystem::path outPath = flattenedOutputPath(path);
+  // A top-level file flattens to its own name, so filterDir == transformDir
+  // makes the "partial output" the input itself.
+  if (std::filesystem::weakly_canonical(path) == std::filesystem::weakly_canonical(outPath))
+    return;
   std::error_code ec;
-  std::filesystem::remove(flattenedOutputPath(path), ec);
+  std::filesystem::remove(outPath, ec);
 }
 
 void Transformer::collectCFiles(std::filesystem::path path, std::vector<std::filesystem::path> &files) {

--- a/src/transform/UnknownTypeDiagConsumer.cpp
+++ b/src/transform/UnknownTypeDiagConsumer.cpp
@@ -9,8 +9,6 @@
 #include <clang/Basic/DiagnosticSema.h>
 #include <clang/Basic/IdentifierTable.h>
 
-#include <cstdlib>
-
 UnknownTypeDiagConsumer::UnknownTypeDiagConsumer(
     std::shared_ptr<std::set<std::string>> unresolvedTypeNames)
     : _UnresolvedTypeNames(unresolvedTypeNames) {
@@ -26,19 +24,26 @@ void UnknownTypeDiagConsumer::HandleDiagnostic(clang::DiagnosticsEngine::Level,
   if (!isUnknownTypename && !isUndeclaredVarUse)
     return;
 
-  // Guarded against a future Clang version diagnostic change
-  if (isUnknownTypename) {
-    if (Info.getArgKind(0) != clang::DiagnosticsEngine::ak_identifierinfo){
-      debugLog(0, "ERROR: Potential Clang Version Issue in UnknownTypeDiag recovery");
-      std::exit(1);
-    }
+  // Clang does not guarantee a diagnostic ID always carries its name
+  // argument with the same encoding: err_undeclared_var_use_suggest (and
+  // presumably its siblings) has been observed emitting the same identifier
+  // as an IdentifierInfo* in one call and a DeclarationName in another,
+  // for the same diagnostic ID, in the same TU. Handle both. Recording
+  // nothing for a genuinely unrecognized encoding is safe: at worst
+  // AddStdIncludesConsumer misses one header, which checkCompilable()
+  // catches downstream -- never worth aborting the whole file over.
+  switch (Info.getArgKind(0)) {
+  case clang::DiagnosticsEngine::ak_identifierinfo:
     _UnresolvedTypeNames->insert(Info.getArgIdentifier(0)->getName().str());
-  } else {
-    if (Info.getArgKind(0) != clang::DiagnosticsEngine::ak_declarationname) {
-      debugLog(0, "ERROR: Potential Clang Version Issue in UnknownTypeDiag recovery");
-      std::exit(1);
-    }
-    clang::DeclarationName name = clang::DeclarationName::getFromOpaqueInteger(Info.getRawArg(0));
-    _UnresolvedTypeNames->insert(name.getAsString());
+    break;
+  case clang::DiagnosticsEngine::ak_declarationname:
+    _UnresolvedTypeNames->insert(
+        clang::DeclarationName::getFromOpaqueInteger(Info.getRawArg(0)).getAsString());
+    break;
+  default:
+    debugLog(2, "UnknownTypeDiagConsumer: diagnostic " + std::to_string(id) +
+                    " arg0 has unrecognized kind " + std::to_string(Info.getArgKind(0)) +
+                    "; skipping");
+    break;
   }
 }

--- a/src/transform/UnknownTypeDiagConsumer.cpp
+++ b/src/transform/UnknownTypeDiagConsumer.cpp
@@ -24,14 +24,13 @@ void UnknownTypeDiagConsumer::HandleDiagnostic(clang::DiagnosticsEngine::Level,
   if (!isUnknownTypename && !isUndeclaredVarUse)
     return;
 
-  // Clang does not guarantee a diagnostic ID always carries its name
-  // argument with the same encoding: err_undeclared_var_use_suggest (and
-  // presumably its siblings) has been observed emitting the same identifier
-  // as an IdentifierInfo* in one call and a DeclarationName in another,
-  // for the same diagnostic ID, in the same TU. Handle both. Recording
-  // nothing for a genuinely unrecognized encoding is safe: at worst
-  // AddStdIncludesConsumer misses one header, which checkCompilable()
-  // catches downstream -- never worth aborting the whole file over.
+  // Clang does not guarantee a diagnostic ID always carries its name argument
+  // with the same encoding: err_undeclared_var_use_suggest emits the same
+  // identifier as an IdentifierInfo* in one call and a DeclarationName in
+  // another, for the same diagnostic ID within one TU. Handle both. Recording
+  // nothing for an unrecognized encoding is safe: at worst
+  // AddStdIncludesConsumer misses one header, which checkCompilable() catches
+  // downstream -- never worth aborting the whole file over.
   switch (Info.getArgKind(0)) {
   case clang::DiagnosticsEngine::ak_identifierinfo:
     _UnresolvedTypeNames->insert(Info.getArgIdentifier(0)->getName().str());

--- a/src/transform/include/Transformer.hpp
+++ b/src/transform/include/Transformer.hpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <vector>
 
 /**
  * @brief Runtime configuration loaded from the INI-style config file.
@@ -22,6 +23,7 @@ struct transformConfigs {
   std::string filterDir;    ///< Input directory containing filtered C files to transform.
   std::string transformDir; ///< Output directory for transformed files (verify-stage input).
   int fileTimeoutSecs;      ///< Wall-clock budget per file for the isolated transform child.
+  int nproc;                ///< Worker pool size (0 = default to hardware concurrency).
   /**
    * Original repo tree the filtered files came from, used only to resolve
    * quoted #includes to -I paths. Empty means no local-header resolution.
@@ -70,18 +72,6 @@ public:
   bool transformFile(std::filesystem::path path);
 
   /**
-   * @brief Runs {@code transformFile} in a forked child for crash isolation.
-   *
-   * The child does the file I/O and reports success through
-   * its exit status; the parent enforces {@code fileTimeoutSecs} and cleans up
-   * any partial output left by a child that crashed or timed out.
-   *
-   * @param path Path to the filtered C source file to transform.
-   * @return 1 if a transformed file was produced, 0 otherwise.
-   */
-  int transformFileIsolated(std::filesystem::path path);
-
-  /**
    * @brief Computes the flattened transformDir output path for a filtered file.
    *
    * @param path Path to the filtered C source file.
@@ -99,10 +89,22 @@ public:
   /**
    * @brief Recursively walks a directory tree, transforming every .c file found.
    *
+   * Collects the matching files, then runs them through a worker pool sized
+   * by {@code configuration.nproc} (each file still isolated in its own
+   * forked child), instead of the old one-file-at-a-time fork+wait.
+   *
    * @param path Root path to search (file or directory).
    * @return Total count of transformed files produced.
    */
   int transformAll(std::filesystem::path path);
+
+  /**
+   * @brief Recursively collects every .c file under path into `files`.
+   *
+   * @param path  Root path to search (file or directory).
+   * @param files Output vector; matching file paths are appended.
+   */
+  void collectCFiles(std::filesystem::path path, std::vector<std::filesystem::path> &files);
 
   /**
    * @brief Parses the config file via the shared {@code parsePipelineConfig},

--- a/src/transform/include/Transformer.hpp
+++ b/src/transform/include/Transformer.hpp
@@ -6,6 +6,7 @@
 
 #include "HavocBounds.hpp"
 #include "IncludeIndex.hpp"
+#include "WorkerPool.hpp"
 
 #include <filesystem>
 #include <optional>
@@ -23,7 +24,7 @@ struct transformConfigs {
   std::string filterDir;    ///< Input directory containing filtered C files to transform.
   std::string transformDir; ///< Output directory for transformed files (verify-stage input).
   int fileTimeoutSecs;      ///< Wall-clock budget per file for the isolated transform child.
-  int nproc;                ///< Worker pool size (0 = default to hardware concurrency).
+  int nproc;                ///< Worker pool size (0 = auto, three quarters of detected cores).
   /**
    * Original repo tree the filtered files came from, used only to resolve
    * quoted #includes to -I paths. Empty means no local-header resolution.
@@ -89,14 +90,13 @@ public:
   /**
    * @brief Recursively walks a directory tree, transforming every .c file found.
    *
-   * Collects the matching files, then runs them through a worker pool sized
-   * by {@code configuration.nproc} (each file still isolated in its own
-   * forked child), instead of the old one-file-at-a-time fork+wait.
+   * Collects the matching files, then runs them through a worker pool sized by
+   * {@code configuration.nproc}, each file isolated in its own forked child.
    *
    * @param path Root path to search (file or directory).
-   * @return Total count of transformed files produced.
+   * @return Per-outcome counts across the tree.
    */
-  int transformAll(std::filesystem::path path);
+  WorkerPoolResult transformAll(std::filesystem::path path);
 
   /**
    * @brief Recursively collects every .c file under path into `files`.

--- a/src/verify/Verifier.cpp
+++ b/src/verify/Verifier.cpp
@@ -74,13 +74,13 @@ bool Verifier::verifyFile(std::filesystem::path path) {
   output.close();
   if (!ran) {
     debugLog(1, "[verify] clang tool failed on: " + path.string());
-    std::filesystem::remove(outPath);
+    cleanupPartialOutput(path);
     return false;
   }
 
   if (harnessIsEmpty(outPath)) {
     debugLog(1, "[verify] discarded (harness empty after re-check): " + outPath.string());
-    std::filesystem::remove(outPath);
+    cleanupPartialOutput(path);
     return false;
   }
 
@@ -88,10 +88,12 @@ bool Verifier::verifyFile(std::filesystem::path path) {
   if (!checkCompilable(outPath)) {
     if (configuration.keepCompilesOnly) {
       debugLog(1, "[verify] discarded (fails compile check): " + outPath.string());
-      std::filesystem::remove(outPath);
+      cleanupPartialOutput(path);
       return false;
     }
-    // Kept for inspection, but not a benchmark: no task file, no .i.
+    // Kept for inspection, but not a benchmark: no task file, no .i. Left on
+    // disk deliberately, so no cleanup here - and none from the pool either,
+    // which never touches a child that exited under its own control.
     debugLog(1, "[verify] kept but not a benchmark (fails compile check): " + outPath.string());
     return false;
   }
@@ -99,10 +101,7 @@ bool Verifier::verifyFile(std::filesystem::path path) {
   writeBenchmarkTask(outPath, *counts);
   if (!preprocess(outPath)) {
     debugLog(0, "Preprocessing failed, discarding: " + outPath.string());
-    std::filesystem::path ymlPath = outPath;
-    ymlPath.replace_extension(".yml");
-    std::filesystem::remove(outPath);
-    std::filesystem::remove(ymlPath);
+    cleanupPartialOutput(path);
     return false;
   }
   return true;
@@ -111,6 +110,9 @@ bool Verifier::verifyFile(std::filesystem::path path) {
 void Verifier::cleanupPartialOutput(std::filesystem::path path) {
   std::filesystem::path outPath =
       std::filesystem::path(configuration.benchmarkDir) / path.filename();
+  // transformDir == benchmarkDir makes the "partial output" the input itself.
+  if (std::filesystem::weakly_canonical(path) == std::filesystem::weakly_canonical(outPath))
+    return;
   std::error_code ec;
   std::filesystem::remove(outPath, ec);
   std::filesystem::path ymlPath = outPath;

--- a/src/verify/Verifier.cpp
+++ b/src/verify/Verifier.cpp
@@ -144,7 +144,7 @@ void Verifier::collectCFiles(std::filesystem::path path, std::vector<std::filesy
   debugLog(3, "[verify] ignored: " + path.filename().string());
 }
 
-int Verifier::verifyAll(std::filesystem::path path) {
+WorkerPoolResult Verifier::verifyAll(std::filesystem::path path) {
   std::vector<std::filesystem::path> files;
   collectCFiles(path, files);
   _totalProcessed = static_cast<int>(files.size());
@@ -159,11 +159,12 @@ int Verifier::verifyAll(std::filesystem::path path) {
     bool produced = verifyFile(p);
     std::cout.flush();
     std::cerr.flush();
-    _exit(produced ? 0 : 1);
+    _exit(produced ? kProducedExit : kDeclinedExit);
   };
   work.runInProcess = [this](const std::filesystem::path &p) { return verifyFile(p); };
   work.cleanupPartial = [this](const std::filesystem::path &p) { cleanupPartialOutput(p); };
   work.debugLog = [](int level, const std::string &msg) { debugLog(level, "[verify] " + msg); };
+  work.label = "verify";
 
   return runWorkerPool(files, workers, configuration.fileTimeoutSecs, work);
 }
@@ -320,11 +321,11 @@ int Verifier::run() {
     return 0;
   }
   writeHarnessHeader();
-  int result = verifyAll(path);
-  int discarded = _totalProcessed - result;
+  WorkerPoolResult result = verifyAll(path);
   std::cout << "\n=== Verify summary ===\n"
             << "  Files processed:        " << _totalProcessed << "\n"
-            << "  Benchmarks produced:    " << result << "\n"
-            << "  Discarded/failed:       " << discarded << std::endl;
-  return result;
+            << "  Benchmarks produced:    " << result.produced << "\n"
+            << "  Declined (no output):   " << result.declined << "\n"
+            << "  Failed:                 " << result.failed << std::endl;
+  return result.produced;
 }

--- a/src/verify/Verifier.cpp
+++ b/src/verify/Verifier.cpp
@@ -156,10 +156,10 @@ int Verifier::verifyAll(std::filesystem::path path) {
 
   IsolatedWork work;
   work.child = [this](const std::filesystem::path &p) {
-    int produced = verifyFile(p) ? 1 : 0;
+    bool produced = verifyFile(p);
     std::cout.flush();
     std::cerr.flush();
-    _exit(produced);
+    _exit(produced ? 0 : 1);
   };
   work.runInProcess = [this](const std::filesystem::path &p) { return verifyFile(p); };
   work.cleanupPartial = [this](const std::filesystem::path &p) { cleanupPartialOutput(p); };

--- a/src/verify/Verifier.cpp
+++ b/src/verify/Verifier.cpp
@@ -9,12 +9,9 @@
 #include "CliArgs.hpp"
 #include "DebugLog.hpp"
 #include "HarnessHeaderData.hpp"
+#include "WorkerPool.hpp"
 
-#include <cerrno>
-#include <csignal>
 #include <cstdlib>
-#include <cstring>
-#include <ctime>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -24,7 +21,6 @@
 #include <optional>
 #include <regex>
 #include <string>
-#include <sys/wait.h>
 #include <system_error>
 #include <unistd.h>
 #include <vector>
@@ -38,6 +34,7 @@ Verifier::Verifier(std::string configFile, std::string inputPath) : configuratio
   configuration.debugLevel = config.fileSettings.at("debugLevel");
   configuration.keepCompilesOnly = config.fileSettings.at("keepCompilesOnly") != 0;
   configuration.fileTimeoutSecs = config.fileSettings.at("fileTimeoutSecs");
+  configuration.nproc = config.fileSettings.at("nproc");
   configuration.transformDir =
       config.transformDir.empty() ? defaultTransformDir : config.transformDir;
   if (!inputPath.empty())
@@ -49,7 +46,7 @@ Verifier::Verifier(std::string configFile, std::string inputPath) : configuratio
 }
 
 bool Verifier::verifyFile(std::filesystem::path path) {
-  debugLog(1, "[verify] file " + std::to_string(_totalProcessed) + ": " + path.string());
+  debugLog(1, "[verify] file: " + path.string());
   if (!std::filesystem::exists(path)) {
     debugLog(1, "[verify] path does not exist: " + path.string());
     return false;
@@ -111,52 +108,6 @@ bool Verifier::verifyFile(std::filesystem::path path) {
   return true;
 }
 
-int Verifier::verifyFileIsolated(std::filesystem::path path) {
-  pid_t pid = fork();
-  if (pid < 0) {
-    debugLog(0, "fork failed, verifying in-process: " + path.string());
-    return verifyFile(path) ? 1 : 0;
-  }
-
-  if (pid == 0) {
-    int produced = verifyFile(path) ? 1 : 0;
-    std::cout.flush();
-    std::cerr.flush();
-    _exit(produced);
-  }
-
-  time_t deadline = time(nullptr) + configuration.fileTimeoutSecs;
-  int status = 0;
-  while (true) {
-    pid_t done = waitpid(pid, &status, WNOHANG);
-    if (done == pid)
-      break;
-    if (done < 0 && errno != EINTR) {
-      debugLog(0, "waitpid failed for " + path.string() + ", killing: " + strerror(errno));
-      kill(pid, SIGKILL);
-      waitpid(pid, &status, 0);
-      cleanupPartialOutput(path);
-      return 0;
-    }
-    if (time(nullptr) >= deadline) {
-      debugLog(0, "Timeout, killing verify of: " + path.string());
-      kill(pid, SIGKILL);
-      waitpid(pid, &status, 0);
-      cleanupPartialOutput(path);
-      return 0;
-    }
-    struct timespec nap = {0, 20 * 1000 * 1000}; // 20ms
-    nanosleep(&nap, nullptr);
-  }
-
-  if (WIFEXITED(status))
-    return WEXITSTATUS(status) == 1 ? 1 : 0;
-  debugLog(0, "Verify crashed (signal " + std::to_string(WTERMSIG(status)) +
-                  "), skipping: " + path.string());
-  cleanupPartialOutput(path);
-  return 0;
-}
-
 void Verifier::cleanupPartialOutput(std::filesystem::path path) {
   std::filesystem::path outPath =
       std::filesystem::path(configuration.benchmarkDir) / path.filename();
@@ -170,31 +121,51 @@ void Verifier::cleanupPartialOutput(std::filesystem::path path) {
   std::filesystem::remove(iPath, ec);
 }
 
-int Verifier::verifyAll(std::filesystem::path path) {
+void Verifier::collectCFiles(std::filesystem::path path, std::vector<std::filesystem::path> &files) {
   if (!std::filesystem::exists(path)) {
     debugLog(1, "[verify] path does not exist: " + path.string());
-    return 0;
+    return;
   }
   if (std::filesystem::is_directory(path)) {
-    int successes = 0;
     for (const std::filesystem::directory_entry &entry :
          std::filesystem::directory_iterator(path)) {
-      successes += verifyAll(entry.path());
+      collectCFiles(entry.path(), files);
     }
-    return successes;
+    return;
   }
   if (std::filesystem::is_regular_file(path)) {
     if (path.extension() == ".c") {
-      _totalProcessed++;
-      if (globalDebugLevel() == 0)
-        std::cout << "\r[verify] " << _totalProcessed << " processed" << std::flush;
-      return verifyFileIsolated(path);
+      files.push_back(path);
+    } else {
+      debugLog(3, "[verify] skipped (not .c): " + path.filename().string());
     }
-    debugLog(3, "[verify] skipped (not .c): " + path.filename().string());
-    return 0;
+    return;
   }
   debugLog(3, "[verify] ignored: " + path.filename().string());
-  return 0;
+}
+
+int Verifier::verifyAll(std::filesystem::path path) {
+  std::vector<std::filesystem::path> files;
+  collectCFiles(path, files);
+  _totalProcessed = static_cast<int>(files.size());
+
+  int workers = resolveWorkerCount(configuration.nproc);
+  debugLog(1, "[verify] worker pool size: " + std::to_string(workers));
+  std::cout << "[verify] processing " << files.size() << " file(s) with " << workers
+            << " worker(s)" << std::endl;
+
+  IsolatedWork work;
+  work.child = [this](const std::filesystem::path &p) {
+    int produced = verifyFile(p) ? 1 : 0;
+    std::cout.flush();
+    std::cerr.flush();
+    _exit(produced);
+  };
+  work.runInProcess = [this](const std::filesystem::path &p) { return verifyFile(p); };
+  work.cleanupPartial = [this](const std::filesystem::path &p) { cleanupPartialOutput(p); };
+  work.debugLog = [](int level, const std::string &msg) { debugLog(level, "[verify] " + msg); };
+
+  return runWorkerPool(files, workers, configuration.fileTimeoutSecs, work);
 }
 
 // NOTE: cmd is passed to std::system (shell-interpreted), and path is not

--- a/src/verify/include/Verifier.hpp
+++ b/src/verify/include/Verifier.hpp
@@ -6,6 +6,7 @@
 
 #include "ConfigParser.hpp"
 #include "CountingVisitor.hpp"
+#include "WorkerPool.hpp"
 
 #include <filesystem>
 #include <string>
@@ -27,7 +28,7 @@ struct verifyConfigs {
   std::string transformDir; ///< Input directory of transformed C files to verify.
   std::string benchmarkDir; ///< Output directory for finalized benchmarks.
   int fileTimeoutSecs;      ///< Wall-clock budget per file for the isolated verify child.
-  int nproc;                ///< Worker pool size (0 = default to hardware concurrency).
+  int nproc;                ///< Worker pool size (0 = auto, three quarters of detected cores).
 };
 
 /**
@@ -77,14 +78,13 @@ public:
   /**
    * @brief Recursively walks a directory tree, verifying every .c file found.
    *
-   * Collects the matching files, then runs them through a worker pool sized
-   * by {@code configuration.nproc} (each file still isolated in its own
-   * forked child), instead of the old one-file-at-a-time fork+wait.
+   * Collects the matching files, then runs them through a worker pool sized by
+   * {@code configuration.nproc}, each file isolated in its own forked child.
    *
    * @param path Root path to search (file or directory).
-   * @return Total count of finalized benchmarks produced.
+   * @return Per-outcome counts across the tree.
    */
-  int verifyAll(std::filesystem::path path);
+  WorkerPoolResult verifyAll(std::filesystem::path path);
 
   /**
    * @brief Recursively collects every .c file under path into `files`.

--- a/src/verify/include/Verifier.hpp
+++ b/src/verify/include/Verifier.hpp
@@ -64,12 +64,15 @@ public:
    * non-compiling results and emits the .yml + .i for survivors.
    *
    * @param path Path to the transformed C source file.
-   * @return true if a finalized benchmark (.c + .yml + .i) was produced.
+   * @return true if a finalized benchmark (.c + .yml + .i) was produced. A
+   *         false return leaves nothing behind except under
+   *         keepCompilesOnly=false, which keeps the non-compiling .c on purpose.
    */
   bool verifyFile(std::filesystem::path path);
 
   /**
-   * @brief Removes any benchmark files a crashed or timed-out child left behind.
+   * @brief Removes this file's benchmark outputs. A no-op when benchmarkDir
+   * resolves to the input's own directory.
    *
    * @param path Path to the transformed C source file whose output to clean up.
    */

--- a/src/verify/include/Verifier.hpp
+++ b/src/verify/include/Verifier.hpp
@@ -27,6 +27,7 @@ struct verifyConfigs {
   std::string transformDir; ///< Input directory of transformed C files to verify.
   std::string benchmarkDir; ///< Output directory for finalized benchmarks.
   int fileTimeoutSecs;      ///< Wall-clock budget per file for the isolated verify child.
+  int nproc;                ///< Worker pool size (0 = default to hardware concurrency).
 };
 
 /**
@@ -67,14 +68,6 @@ public:
   bool verifyFile(std::filesystem::path path);
 
   /**
-   * @brief Runs {@code verifyFile} in a forked child for crash isolation.
-   *
-   * @param path Path to the transformed C source file.
-   * @return 1 if a finalized benchmark was produced, 0 otherwise.
-   */
-  int verifyFileIsolated(std::filesystem::path path);
-
-  /**
    * @brief Removes any benchmark files a crashed or timed-out child left behind.
    *
    * @param path Path to the transformed C source file whose output to clean up.
@@ -84,10 +77,22 @@ public:
   /**
    * @brief Recursively walks a directory tree, verifying every .c file found.
    *
+   * Collects the matching files, then runs them through a worker pool sized
+   * by {@code configuration.nproc} (each file still isolated in its own
+   * forked child), instead of the old one-file-at-a-time fork+wait.
+   *
    * @param path Root path to search (file or directory).
    * @return Total count of finalized benchmarks produced.
    */
   int verifyAll(std::filesystem::path path);
+
+  /**
+   * @brief Recursively collects every .c file under path into `files`.
+   *
+   * @param path  Root path to search (file or directory).
+   * @param files Output vector; matching file paths are appended.
+   */
+  void collectCFiles(std::filesystem::path path, std::vector<std::filesystem::path> &files);
 
   /**
    * @brief Checks whether a verified file compiles without errors.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(filter_tests
   common/ClangToolUtilsTest.cpp
   common/ConfigParserTest.cpp
   common/IncludeIndexTest.cpp
+  common/WorkerPoolTest.cpp
   filter/CountingVisitorTest.cpp
   filter/FilterFunctionsConsumerTest.cpp
   filter/FiltererStageTest.cpp

--- a/tests/common/WorkerPoolTest.cpp
+++ b/tests/common/WorkerPoolTest.cpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 The ARG-V Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "WorkerPool.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <functional>
+#include <gtest/gtest.h>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+// ---------------------------------------------------------------------------
+// Unit tests for the shared worker pool
+// ---------------------------------------------------------------------------
+//
+// The stages differ only in what their IsolatedWork callbacks do, so these
+// drive the pool with synthetic work that exits however a test needs.
+// cleanupPartial runs in the parent, so a test can record its calls directly.
+
+namespace {
+
+/** Collects the pool's parent-side callbacks for assertions. */
+struct Recorder {
+  std::vector<std::string> cleaned;
+
+  IsolatedWork work(std::function<void(const fs::path &)> child,
+                    std::function<bool(const fs::path &)> inProcess = nullptr) {
+    IsolatedWork w;
+    w.child = std::move(child);
+    w.runInProcess = inProcess ? std::move(inProcess) : [](const fs::path &) { return false; };
+    w.cleanupPartial = [this](const fs::path &p) { cleaned.push_back(p.filename().string()); };
+    w.debugLog = [](int, const std::string &) {};
+    w.label = "test";
+    return w;
+  }
+};
+
+std::vector<fs::path> paths(std::initializer_list<std::string> names) {
+  std::vector<fs::path> out;
+  for (const std::string &n : names)
+    out.emplace_back(n);
+  return out;
+}
+
+/** A child that exits with `code` for every file. */
+std::function<void(const fs::path &)> childExiting(int code) {
+  return [code](const fs::path &) { _exit(code); };
+}
+
+} // namespace
+
+TEST(ResolveWorkerCount, PositiveConfigValueIsUsedVerbatim) {
+  EXPECT_EQ(resolveWorkerCount(1), 1);
+  unsigned hw = std::thread::hardware_concurrency();
+  if (hw > 1)
+    EXPECT_EQ(resolveWorkerCount(static_cast<int>(hw) - 1), static_cast<int>(hw) - 1);
+}
+
+TEST(ResolveWorkerCount, OversubscriptionIsClampedToTheCoreCountWithAWarning) {
+  unsigned hw = std::thread::hardware_concurrency();
+  if (hw == 0)
+    GTEST_SKIP() << "no detectable core count";
+
+  testing::internal::CaptureStderr();
+  int workers = resolveWorkerCount(static_cast<int>(hw) + 4);
+  std::string warning = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(workers, static_cast<int>(hw));
+  EXPECT_NE(warning.find("exceeds"), std::string::npos) << warning;
+}
+
+// At or below the core count the configured value is used as-is, silently.
+TEST(ResolveWorkerCount, CountWithinTheCoreCountIsNotWarnedAbout) {
+  unsigned hw = std::thread::hardware_concurrency();
+  if (hw == 0)
+    GTEST_SKIP() << "no detectable core count";
+
+  testing::internal::CaptureStderr();
+  int workers = resolveWorkerCount(static_cast<int>(hw));
+  std::string warning = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(workers, static_cast<int>(hw));
+  EXPECT_TRUE(warning.empty()) << warning;
+}
+
+TEST(ResolveWorkerCount, ZeroAutoSizesBelowCoreCountButAtLeastOne) {
+  int workers = resolveWorkerCount(0);
+  EXPECT_GE(workers, 1);
+  unsigned hw = std::thread::hardware_concurrency();
+  if (hw > 0)
+    EXPECT_LE(workers, static_cast<int>(hw));
+}
+
+TEST(WorkerPool, ProducedFilesAreCountedAndLeftAlone) {
+  Recorder rec;
+  IsolatedWork work = rec.work(childExiting(kProducedExit));
+
+  WorkerPoolResult result = runWorkerPool(paths({"a.c", "b.c"}), 2, 30, work);
+
+  EXPECT_EQ(result.produced, 2);
+  EXPECT_EQ(result.declined, 0);
+  EXPECT_EQ(result.failed, 0);
+  EXPECT_TRUE(rec.cleaned.empty());
+}
+
+// A child that exits under its own control owns its residue - including the
+// non-compiling .c verify keeps under keepCompilesOnly=false - so the pool
+// must leave the filesystem alone.
+TEST(WorkerPool, DeclineDoesNotTriggerCleanup) {
+  Recorder rec;
+  IsolatedWork work = rec.work(childExiting(kDeclinedExit));
+
+  WorkerPoolResult result = runWorkerPool(paths({"a.c"}), 2, 30, work);
+
+  EXPECT_EQ(result.declined, 1);
+  EXPECT_EQ(result.produced, 0);
+  EXPECT_TRUE(rec.cleaned.empty());
+}
+
+TEST(WorkerPool, CrashedChildIsFailedAndCleanedUp) {
+  Recorder rec;
+  IsolatedWork work = rec.work([](const fs::path &) { abort(); });
+
+  WorkerPoolResult result = runWorkerPool(paths({"a.c"}), 2, 30, work);
+
+  EXPECT_EQ(result.failed, 1);
+  EXPECT_EQ(result.produced, 0);
+  EXPECT_EQ(rec.cleaned, std::vector<std::string>{"a.c"});
+}
+
+// Any exit code the contract does not name is a failure, not a decline - the
+// point of keeping kDeclinedExit off 1.
+TEST(WorkerPool, UnexpectedExitCodeIsFailure) {
+  Recorder rec;
+  IsolatedWork work = rec.work([](const fs::path &) { _exit(1); });
+
+  WorkerPoolResult result = runWorkerPool(paths({"a.c"}), 2, 30, work);
+
+  EXPECT_EQ(result.failed, 1);
+  EXPECT_EQ(result.declined, 0);
+  EXPECT_EQ(rec.cleaned, std::vector<std::string>{"a.c"});
+}
+
+TEST(WorkerPool, ChildOverrunningTheBudgetIsKilledAndCleanedUp) {
+  Recorder rec;
+  IsolatedWork work = rec.work([](const fs::path &) {
+    sleep(30);
+    _exit(kProducedExit);
+  });
+
+  WorkerPoolResult result = runWorkerPool(paths({"a.c"}), 2, 1, work);
+
+  EXPECT_EQ(result.failed, 1);
+  EXPECT_EQ(result.produced, 0);
+  EXPECT_EQ(rec.cleaned, std::vector<std::string>{"a.c"});
+}
+
+// One slow file must not stop the pool from finishing the rest.
+TEST(WorkerPool, TimeoutIsPerFileNotPerPool) {
+  Recorder rec;
+  IsolatedWork work = rec.work([](const fs::path &p) {
+    if (p.filename() == "slow.c")
+      sleep(30);
+    _exit(kProducedExit);
+  });
+
+  WorkerPoolResult result = runWorkerPool(paths({"slow.c", "a.c", "b.c"}), 3, 1, work);
+
+  EXPECT_EQ(result.produced, 2);
+  EXPECT_EQ(result.failed, 1);
+  EXPECT_EQ(rec.cleaned, std::vector<std::string>{"slow.c"});
+}
+
+// More files than slots: every file is still dispatched exactly once, and the
+// counts account for all of them.
+TEST(WorkerPool, EveryFileIsProcessedWhenFilesOutnumberWorkers) {
+  Recorder rec;
+  IsolatedWork work = rec.work([](const fs::path &p) {
+    // Alternate outcomes so the reap loop is exercised on both branches.
+    _exit(p.filename().string()[0] % 2 ? kProducedExit : kDeclinedExit);
+  });
+
+  std::vector<fs::path> files;
+  for (int i = 0; i < 20; i++)
+    files.emplace_back(std::string(1, static_cast<char>('a' + i)) + ".c");
+
+  WorkerPoolResult result = runWorkerPool(files, 3, 30, work);
+
+  EXPECT_EQ(result.produced + result.declined + result.failed, static_cast<int>(files.size()));
+  EXPECT_EQ(result.failed, 0);
+  EXPECT_TRUE(rec.cleaned.empty());
+}
+
+TEST(WorkerPool, EmptyInputProducesEmptyResult) {
+  Recorder rec;
+  IsolatedWork work = rec.work(childExiting(kProducedExit));
+
+  WorkerPoolResult result = runWorkerPool({}, 4, 30, work);
+
+  EXPECT_EQ(result.produced, 0);
+  EXPECT_EQ(result.declined, 0);
+  EXPECT_EQ(result.failed, 0);
+}
+
+// A child's stderr goes to a private log the parent flushes on reap, so the
+// pool must not leave those temp files behind.
+TEST(WorkerPool, ChildLogDirectoryIsRemovedAfterTheRun) {
+  Recorder rec;
+  IsolatedWork work = rec.work([](const fs::path &) {
+    fprintf(stderr, "noise from the child\n");
+    _exit(kProducedExit);
+  });
+
+  runWorkerPool(paths({"a.c"}), 2, 30, work);
+
+  fs::path logDir = fs::temp_directory_path() / ("argv-c-pool-" + std::to_string(getpid()));
+  EXPECT_FALSE(fs::exists(logDir));
+}
+

--- a/tests/filter/FiltererStageTest.cpp
+++ b/tests/filter/FiltererStageTest.cpp
@@ -185,3 +185,21 @@ TEST_F(FiltererStageTest, StripsFunctionFailingComplexityThreshold) {
   EXPECT_NE(out.find("int plain(int x) ;"), std::string::npos) << out;
   EXPECT_EQ(out.find("return x + 1;"), std::string::npos) << out;
 }
+
+// filterFile refuses to run when the output path resolves to the input, so
+// every file declines - and the decline must not take the source with it.
+TEST_F(FiltererStageTest, DatabaseDirEqualToFilterDirLeavesTheSourceIntact) {
+  std::ofstream cfg(configPath);
+  cfg << "[File Locations]\n"
+      << "databaseDir = " << databaseDir.string() << "\n"
+      << "filterDir = " << databaseDir.string() << "\n"
+      << "[Debug]\n"
+      << "debugLevel = 0\n";
+  cfg.close();
+  writeFile(databaseDir / "keepme.c", "int add(int a, int b) { return a + b; }\n");
+
+  Filterer f(configPath.string());
+  f.run();
+
+  EXPECT_TRUE(fs::exists(databaseDir / "keepme.c"));
+}

--- a/tests/verify/VerifyStageTest.cpp
+++ b/tests/verify/VerifyStageTest.cpp
@@ -300,12 +300,15 @@ TEST_F(VerifyStageTest, HarnessEmptyAfterRepairIsDiscarded) {
 TEST_F(VerifyStageTest, KeepCompilesOnlyDiscardsUndefinedTypes) {
   // Uses a type from a local header that gets stripped during transform -
   // the transformed file parses but won't compile, so keepCompilesOnly
-  // (default true) should discard it in the verify stage.
+  // (default true) should discard it in the verify stage. The param is an int
+  // so the function stays harnessable and the file actually reaches verify.
   writeFile(filterDir / "local_types.h",
             "typedef struct { int id; } widget_t;\n");
   writeFile(filterDir / "badtype.c",
             "#include \"local_types.h\"\n"
-            "int process(widget_t w) {\n"
+            "int process(int n) {\n"
+            "  widget_t w;\n"
+            "  w.id = n;\n"
             "  return w.id + 1;\n"
             "}\n");
 
@@ -362,4 +365,30 @@ TEST_F(VerifyStageTest, ArgcArgvMainSurvivesVerify) {
 
   std::string src = readFile(benchmarkDir / "withmain.c");
   EXPECT_NE(src.find("original_main(argc, __havoc_argv_fill(argc));"), std::string::npos);
+}
+
+// The counterpart to KeepCompilesOnlyDiscardsUndefinedTypes: with the flag
+// off, the non-compiling .c is kept for inspection - no .yml, no .i - and the
+// worker pool must not treat that decline as residue to clean up.
+TEST_F(VerifyStageTest, KeepCompilesOnlyFalseKeepsNonCompilingSource) {
+  writeConfig("keepCompilesOnly = false\n");
+  writeFile(filterDir / "local_types.h",
+            "typedef struct { int id; } widget_t;\n");
+  // An int param keeps the function harnessable, so transform emits a real
+  // main and the file survives to verify; widget_t is only declared in the
+  // local header transform strips, so the result parses but will not compile.
+  writeFile(filterDir / "badtype.c",
+            "#include \"local_types.h\"\n"
+            "int process(int n) {\n"
+            "  widget_t w;\n"
+            "  w.id = n;\n"
+            "  return w.id + 1;\n"
+            "}\n");
+
+  int count = transformAndVerify();
+
+  EXPECT_EQ(count, 0);
+  EXPECT_TRUE(fs::exists(benchmarkDir / "badtype.c"));
+  EXPECT_FALSE(fs::exists(benchmarkDir / "badtype.yml"));
+  EXPECT_FALSE(fs::exists(benchmarkDir / "badtype.i"));
 }


### PR DESCRIPTION
This PR introduces multi-threading to the pipeline making runs much faster.

Previously each stage forked a child per file for crash isolation. This replaces the three near-identical fork/poll/timeout loops in Filterer, Transformer, and Verifier with one shared `runWorkerPool` (src/common/include/WorkerPool.hpp) that keeps N children in flight.

Worker count comes from a new `nproc` config key: 0 (default) auto-sizes to three quarters of detected cores, positive values are used verbatim and capped at the core count with a warning.